### PR TITLE
fix: remediate repo audit findings from 2026-02-23

### DIFF
--- a/app/composables/__tests__/useBeatportScraper.test.ts
+++ b/app/composables/__tests__/useBeatportScraper.test.ts
@@ -3,7 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mockFetch = vi.fn()
 vi.stubGlobal('$fetch', mockFetch)
 
-const { useBeatportScraper } = await import('../useBeatportScraper')
+const { useBeatportScraper, BeatportScraperError } = await import(
+	'../useBeatportScraper'
+)
 
 describe('useBeatportScraper', () => {
 	beforeEach(() => {
@@ -31,7 +33,10 @@ describe('useBeatportScraper', () => {
 	})
 
 	it('passes encoded query and match params to endpoint', async () => {
-		mockFetch.mockResolvedValue({ success: false, error: 'No match' })
+		mockFetch.mockResolvedValue({
+			success: false,
+			error: 'No matching track found'
+		})
 
 		const { searchTracks } = useBeatportScraper()
 		await searchTracks({ artist: 'Artist & Friends', title: 'Track (Remix)' })
@@ -45,8 +50,11 @@ describe('useBeatportScraper', () => {
 		expect(requestUrl).toContain(`title=${encodeURIComponent('Track (Remix)')}`)
 	})
 
-	it('returns null when response is not successful', async () => {
-		mockFetch.mockResolvedValue({ success: false, error: 'No match' })
+	it('returns null only for explicit no-match payload', async () => {
+		mockFetch.mockResolvedValue({
+			success: false,
+			error: 'No matching track found'
+		})
 
 		const { searchTracks } = useBeatportScraper()
 		const result = await searchTracks({ artist: 'Missing', title: 'Track' })
@@ -54,15 +62,42 @@ describe('useBeatportScraper', () => {
 		expect(result).toBeNull()
 	})
 
-	it('returns null when fetch throws', async () => {
-		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+	it('throws typed error for unsuccessful non no-match payload', async () => {
+		mockFetch.mockResolvedValue({ success: false, error: 'Too many requests' })
+
+		const { searchTracks } = useBeatportScraper()
+		await expect(
+			searchTracks({ artist: 'Test Artist', title: 'Track' })
+		).rejects.toMatchObject({
+			name: 'BeatportScraperError',
+			type: 'api'
+		})
+	})
+
+	it('throws typed transport error when fetch throws without status', async () => {
 		mockFetch.mockRejectedValue(new Error('Network error'))
 
 		const { searchTracks } = useBeatportScraper()
-		const result = await searchTracks({ artist: 'Test Artist', title: 'Track' })
+		await expect(
+			searchTracks({ artist: 'Test Artist', title: 'Track' })
+		).rejects.toBeInstanceOf(BeatportScraperError)
+		await expect(
+			searchTracks({ artist: 'Test Artist', title: 'Track' })
+		).rejects.toMatchObject({
+			type: 'transport',
+			statusCode: null
+		})
+	})
 
-		expect(result).toBeNull()
-		expect(consoleSpy).toHaveBeenCalled()
-		consoleSpy.mockRestore()
+	it('throws typed api error when fetch throws with status', async () => {
+		mockFetch.mockRejectedValue({ statusCode: 429, message: 'Too many requests' })
+
+		const { searchTracks } = useBeatportScraper()
+		await expect(
+			searchTracks({ artist: 'Test Artist', title: 'Track' })
+		).rejects.toMatchObject({
+			type: 'api',
+			statusCode: 429
+		})
 	})
 })

--- a/app/composables/useBeatportScraper.ts
+++ b/app/composables/useBeatportScraper.ts
@@ -18,6 +18,59 @@ interface BeatportResponse {
 	error?: string
 }
 
+const BEATPORT_NO_MATCH_ERROR = 'No matching track found'
+
+type BeatportScraperErrorType = 'api' | 'transport'
+
+export class BeatportScraperError extends Error {
+	readonly type: BeatportScraperErrorType
+	readonly statusCode: number | null
+	readonly originalError: unknown
+
+	constructor(
+		message: string,
+		{
+			type,
+			statusCode = null,
+			originalError
+		}: {
+			type: BeatportScraperErrorType
+			statusCode?: number | null
+			originalError: unknown
+		}
+	) {
+		super(message)
+		this.name = 'BeatportScraperError'
+		this.type = type
+		this.statusCode = statusCode
+		this.originalError = originalError
+	}
+}
+
+function isNoMatchResponse(response: BeatportResponse): boolean {
+	return (
+		response.success === false && response.error === BEATPORT_NO_MATCH_ERROR
+	)
+}
+
+function getStatusCode(error: unknown): number | null {
+	if (!error || typeof error !== 'object') return null
+
+	const maybeError = error as {
+		statusCode?: unknown
+		status?: unknown
+		response?: { status?: unknown }
+	}
+
+	if (typeof maybeError.statusCode === 'number') return maybeError.statusCode
+	if (typeof maybeError.status === 'number') return maybeError.status
+	if (typeof maybeError.response?.status === 'number') {
+		return maybeError.response.status
+	}
+
+	return null
+}
+
 export function useBeatportScraper() {
 	const searchTracks = async ({
 		artist,
@@ -33,10 +86,36 @@ export function useBeatportScraper() {
 				return response.data
 			}
 
-			return null
+			if (isNoMatchResponse(response)) {
+				return null
+			}
+
+			throw new BeatportScraperError(
+				`Beatport API response failed: ${response.error ?? 'Unknown API error'}`,
+				{
+					type: 'api',
+					originalError: response
+				}
+			)
 		} catch (error) {
-			console.error('Failed to search Beatport:', error)
-			return null
+			if (error instanceof BeatportScraperError) {
+				throw error
+			}
+
+			const statusCode = getStatusCode(error)
+			const type: BeatportScraperErrorType =
+				statusCode !== null ? 'api' : 'transport'
+			const statusCodeMessage =
+				statusCode !== null ? ` (${statusCode})` : ''
+
+			throw new BeatportScraperError(
+				`Failed to search Beatport${statusCodeMessage}`,
+				{
+					type,
+					statusCode,
+					originalError: error
+				}
+			)
 		}
 	}
 

--- a/app/stores/__tests__/beatportStore.test.ts
+++ b/app/stores/__tests__/beatportStore.test.ts
@@ -299,6 +299,15 @@ describe('beatportStore', () => {
 			expect(result).toBe(false)
 			expect(store.isLoadingBeatportData).toBe(false)
 			expect(consoleSpy).toHaveBeenCalled()
+			expect(mockTracksStore.updateTrack).not.toHaveBeenCalledWith(
+				'track-1',
+				expect.objectContaining({
+					beatport_data: expect.objectContaining({
+						notFound: true
+					})
+				}),
+				{ silent: true }
+			)
 			consoleSpy.mockRestore()
 		})
 	})
@@ -457,6 +466,75 @@ describe('beatportStore', () => {
 
 			expect(store.lastProcessedTrack).not.toBeNull()
 			expect(store.lastProcessedTrack?.trackId).toBe('track-1')
+		})
+
+		it('does not write notFound marker on transient scraper failure', async () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+			const store = useBeatportStore()
+			const track = createMockTrack({ id: 'track-1', beatport_data: null })
+			mockTracksStore.tracks = [track]
+			mockTracksStore.getTrackById.mockReturnValue(track)
+			mockBeatportScraper.searchTracks.mockRejectedValue(
+				Object.assign(new Error('Failed to search Beatport (429)'), {
+					name: 'BeatportScraperError',
+					type: 'api',
+					statusCode: 429
+				})
+			)
+
+			await store.bulkFetchBeatportData()
+
+			expect(mockTracksStore.updateTrack).not.toHaveBeenCalledWith(
+				'track-1',
+				expect.objectContaining({
+					beatport_data: expect.objectContaining({
+						notFound: true
+					})
+				}),
+				{ silent: true }
+			)
+			consoleSpy.mockRestore()
+		})
+
+		it('retries transient scraper failure in a later bulk run', async () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+			const store = useBeatportStore()
+			const track = createMockTrack({ id: 'track-1', beatport_data: null })
+			mockTracksStore.tracks = [track]
+			mockTracksStore.getTrackById.mockImplementation((id: string) =>
+				mockTracksStore.tracks.find((t) => t.id === id)
+			)
+			mockBeatportScraper.searchTracks
+				.mockRejectedValueOnce(
+					Object.assign(new Error('Failed to search Beatport (504)'), {
+						name: 'BeatportScraperError',
+						type: 'api',
+						statusCode: 504
+					})
+				)
+				.mockResolvedValueOnce({
+					url: 'https://beatport.com/track/123',
+					bpm: 128
+				})
+			mockTracksStore.updateTrack.mockImplementation(
+				(id: string, updates: { beatport_data?: { url?: string; bpm?: number } }) => {
+					const target = mockTracksStore.tracks.find((t) => t.id === id)
+					if (target && updates.beatport_data) {
+						target.beatport_data = updates.beatport_data
+					}
+					return target
+				}
+			)
+
+			await store.bulkFetchBeatportData()
+			expect(store.bulkBeatportResults.successful).toBe(0)
+			expect(store.bulkBeatportResults.failed).toHaveLength(1)
+			expect(track.beatport_data).toBeNull()
+
+			await store.bulkFetchBeatportData()
+			expect(mockBeatportScraper.searchTracks).toHaveBeenCalledTimes(2)
+			expect(store.bulkBeatportResults.successful).toBe(1)
+			consoleSpy.mockRestore()
 		})
 	})
 

--- a/app/stores/__tests__/beatportStore.test.ts
+++ b/app/stores/__tests__/beatportStore.test.ts
@@ -436,6 +436,41 @@ describe('beatportStore', () => {
 			expect(store.bulkBeatportProgress).toBe(100)
 		})
 
+		it('spaces Beatport requests between bulk items', async () => {
+			const store = useBeatportStore()
+			const tracks = [
+				createMockTrack({ id: 'track-1', beatport_data: null }),
+				createMockTrack({ id: 'track-2', beatport_data: null })
+			]
+			mockTracksStore.tracks = tracks
+			mockTracksStore.getTrackById.mockImplementation((id: string) =>
+				tracks.find((t) => t.id === id)
+			)
+			mockBeatportScraper.searchTracks.mockResolvedValue(null)
+			mockTracksStore.updateTrack.mockImplementation((id: string) =>
+				tracks.find((t) => t.id === id)
+			)
+
+			vi.useFakeTimers()
+
+			try {
+				const bulkPromise = store.bulkFetchBeatportData()
+				await Promise.resolve()
+
+				expect(mockBeatportScraper.searchTracks).toHaveBeenCalledTimes(1)
+
+				await vi.advanceTimersByTimeAsync(999)
+				expect(mockBeatportScraper.searchTracks).toHaveBeenCalledTimes(1)
+
+				await vi.advanceTimersByTimeAsync(1)
+				expect(mockBeatportScraper.searchTracks).toHaveBeenCalledTimes(2)
+
+				await bulkPromise
+			} finally {
+				vi.useRealTimers()
+			}
+		})
+
 		it('updates currentProcessingTrack during bulk operation', async () => {
 			const store = useBeatportStore()
 			const track = createMockTrack({ id: 'track-1', beatport_data: null })

--- a/app/stores/beatportStore.ts
+++ b/app/stores/beatportStore.ts
@@ -29,6 +29,8 @@ interface BeatportNotFoundMarker {
 	searchedAt: number
 }
 
+const BEATPORT_BULK_REQUEST_INTERVAL_MS = 1000
+
 // Helper to check if track has been searched (found or not found)
 function hasBeenSearched(
 	beatportData: BeatportTrackData | BeatportNotFoundMarker | null
@@ -51,6 +53,10 @@ function hasFoundData(
 		'url' in beatportData &&
 		(!!beatportData.url || beatportData.bpm !== undefined)
 	)
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 export const useBeatportStore = defineStore('beatport', () => {
@@ -258,6 +264,11 @@ export const useBeatportStore = defineStore('beatport', () => {
 			bulkBeatportProgress.value = Math.round(
 				((i + 1) / tracksToProcess.length) * 100
 			)
+
+			const hasMoreTracks = i < tracksToProcess.length - 1
+			if (!bulkBeatportCancelled.value && hasMoreTracks) {
+				await sleep(BEATPORT_BULK_REQUEST_INTERVAL_MS)
+			}
 		}
 
 		isBulkFetchingBeatportData.value = false

--- a/app/stores/beatportStore.ts
+++ b/app/stores/beatportStore.ts
@@ -312,7 +312,7 @@ export const useBeatportStore = defineStore('beatport', () => {
 			return result !== null
 		} catch (error) {
 			console.error('Error fetching Beatport data:', error)
-			return false
+			throw error
 		}
 	}
 

--- a/app/stores/discogsAuthStore.ts
+++ b/app/stores/discogsAuthStore.ts
@@ -72,11 +72,15 @@ export const useDiscogsAuthStore = defineStore('discogsAuth', () => {
 				) {
 					rawMessage = payload.error
 				}
-			} catch {}
+			} catch {
+				// Intentionally ignore JSON parsing failures and fall back to text parsing.
+			}
 			try {
 				const text = await context.text()
 				if (!rawMessage && text) rawMessage = text
-			} catch {}
+			} catch {
+				// Intentionally ignore text parsing failures and fall back to error.message.
+			}
 		}
 
 		if (!rawMessage && error instanceof Error && error.message) {

--- a/docs/discogs-integration.md
+++ b/docs/discogs-integration.md
@@ -151,6 +151,7 @@ Comprehensive TypeScript types and runtime validation ensure data integrity thro
 ### Database Atomicity
 
 The `import_record_with_tracks` RPC function ensures that records and their tracks are inserted atomically, preventing partial imports on database errors.
+On success it returns `{ success: true, record_id, tracks_inserted }`; authentication/validation/SQL failures are raised and surface to clients as RPC errors (not `{ success: false, error }` payloads).
 
 ## Usage for Future Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"tailwindcss-animate": "^1.0.7",
 				"tw-animate-css": "^1.4.0",
 				"vee-validate": "^4.15.1",
-				"vue": "latest",
+				"vue": "3.5.28",
 				"vue-sonner": "^2.0.9",
 				"zod": "^3.25.76"
 			},

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"tailwindcss-animate": "^1.0.7",
 		"tw-animate-css": "^1.4.0",
 		"vee-validate": "^4.15.1",
-		"vue": "latest",
+		"vue": "3.5.28",
 		"vue-sonner": "^2.0.9",
 		"zod": "^3.25.76"
 	},
@@ -80,7 +80,7 @@
 		"vue-tsc": "^3.2.4"
 	},
 	"overrides": {
-		"vue": "latest"
+		"vue": "3.5.28"
 	},
 	"prettier": {
 		"useTabs": true,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"supa:restart": "supabase stop && supabase start",
 		"supa:functions": "supabase functions serve --no-verify-jwt",
 		"supa:reset": "supabase db reset",
-		"setStagingSecrets": "npx supabase secrets set --project-ref=luhufzpayswbgewenudn --env-file ./supabase/.env",
+		"setStagingSecrets": "npx supabase secrets set --project-ref=luhufzpayswbgewenudn --env-file ./supabase/functions/.env",
 		"genTypes": "supabase gen types --lang=typescript --local > shared/types/database.ts && supabase gen types --lang=typescript --local > supabase/functions/_shared/types/database.ts"
 	},
 	"dependencies": {

--- a/server/api/beatport/search.get.test.ts
+++ b/server/api/beatport/search.get.test.ts
@@ -389,9 +389,7 @@ describe('beatport/search API', () => {
 			}
 		})
 
-		it('throws 500 error when Beatport returns rate limit (429)', async () => {
-			// Note: The endpoint's catch block converts all fetch-related errors to 500
-			// A future improvement could preserve the original status code
+		it('throws 429 error when Beatport returns rate limit (429)', async () => {
 			mockGetQuery.mockReturnValue({
 				q: 'Test Artist Test Track',
 				artist: 'Test Artist',
@@ -404,8 +402,8 @@ describe('beatport/search API', () => {
 			})
 
 			await expect(handler({})).rejects.toMatchObject({
-				statusCode: 500,
-				message: 'Failed to fetch from Beatport'
+				statusCode: 429,
+				message: 'Beatport returned 429'
 			})
 		})
 
@@ -424,8 +422,26 @@ describe('beatport/search API', () => {
 			})
 		})
 
-		it('throws 500 error when Beatport returns 503', async () => {
-			// Note: The endpoint's catch block converts all fetch-related errors to 500
+		it('throws 500 error when fetch rejects with statusCode error', async () => {
+			mockGetQuery.mockReturnValue({
+				q: 'Test Artist Test Track',
+				artist: 'Test Artist',
+				title: 'Test Track'
+			})
+
+			const fetchError = new Error('Network failure') as Error & {
+				statusCode: number
+			}
+			fetchError.statusCode = 429
+			mockFetch.mockRejectedValueOnce(fetchError)
+
+			await expect(handler({})).rejects.toMatchObject({
+				statusCode: 500,
+				message: 'Failed to fetch from Beatport'
+			})
+		})
+
+		it('throws 503 error when Beatport returns 503', async () => {
 			mockGetQuery.mockReturnValue({
 				q: 'Test Artist Test Track',
 				artist: 'Test Artist',
@@ -438,8 +454,8 @@ describe('beatport/search API', () => {
 			})
 
 			await expect(handler({})).rejects.toMatchObject({
-				statusCode: 500,
-				message: 'Failed to fetch from Beatport'
+				statusCode: 503,
+				message: 'Beatport returned 503'
 			})
 		})
 	})

--- a/server/api/beatport/search.get.test.ts
+++ b/server/api/beatport/search.get.test.ts
@@ -346,14 +346,76 @@ describe('beatport/search API', () => {
 				}
 			}
 
-			await handler(event)
+			vi.useFakeTimers()
+			vi.setSystemTime(new Date('2026-02-24T00:00:00.000Z'))
 
-			await expect(handler(event)).rejects.toMatchObject({
-				statusCode: 429,
-				message: 'Too many requests'
+			try {
+				await handler(event)
+
+				await expect(handler(event)).rejects.toMatchObject({
+					statusCode: 429,
+					message: 'Too many requests'
+				})
+
+				expect(mockFetch).toHaveBeenCalledTimes(1)
+			} finally {
+				vi.useRealTimers()
+			}
+		})
+
+		it('does not consume user quota when shared IP is rate limited', async () => {
+			mockGetQuery.mockReturnValue({
+				q: 'Test Artist Test Track',
+				artist: 'Test Artist',
+				title: 'Test Track'
+			})
+			mockServerSupabaseUser
+				.mockResolvedValueOnce({ id: 'user-1' })
+				.mockResolvedValueOnce({ id: 'user-2' })
+				.mockResolvedValueOnce({ id: 'user-2' })
+
+			mockFetch.mockResolvedValue({
+				ok: true,
+				text: () => Promise.resolve('<html><body></body></html>')
 			})
 
-			expect(mockFetch).toHaveBeenCalledTimes(1)
+			const sharedIpEvent = {
+				node: {
+					req: {
+						headers: { 'x-forwarded-for': '203.0.113.5' },
+						socket: { remoteAddress: '203.0.113.5' }
+					}
+				}
+			}
+			const alternateIpEvent = {
+				node: {
+					req: {
+						headers: { 'x-forwarded-for': '203.0.113.6' },
+						socket: { remoteAddress: '203.0.113.6' }
+					}
+				}
+			}
+
+			vi.useFakeTimers()
+			vi.setSystemTime(new Date('2026-02-24T00:00:00.000Z'))
+
+			try {
+				await handler(sharedIpEvent)
+
+				await expect(handler(sharedIpEvent)).rejects.toMatchObject({
+					statusCode: 429,
+					message: 'Too many requests'
+				})
+
+				await expect(handler(alternateIpEvent)).resolves.toMatchObject({
+					success: false,
+					error: 'No matching track found'
+				})
+
+				expect(mockFetch).toHaveBeenCalledTimes(2)
+			} finally {
+				vi.useRealTimers()
+			}
 		})
 
 		it('throws 504 error when Beatport request times out', async () => {

--- a/server/api/beatport/search.get.test.ts
+++ b/server/api/beatport/search.get.test.ts
@@ -15,6 +15,9 @@ const mockCreateError = vi.fn(
 vi.stubGlobal('getQuery', mockGetQuery)
 vi.stubGlobal('createError', mockCreateError)
 
+const mockServerSupabaseUser = vi.fn()
+vi.stubGlobal('serverSupabaseUser', mockServerSupabaseUser)
+
 // Mock global fetch
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
@@ -36,10 +39,25 @@ describe('beatport/search API', () => {
 		mockGetQuery.mockReset()
 		mockCreateError.mockClear()
 		mockFetch.mockReset()
+		mockServerSupabaseUser.mockReset()
+		mockServerSupabaseUser.mockResolvedValue({ id: 'user-123' })
 
 		// Re-import handler to get fresh module with mocks
 		const module = await import('./search.get')
 		handler = module.default
+	})
+
+	describe('authentication', () => {
+		it('returns 401 when user is not authenticated', async () => {
+			mockServerSupabaseUser.mockResolvedValueOnce(null)
+
+			await expect(handler({})).rejects.toMatchObject({
+				statusCode: 401,
+				message: 'Authentication required'
+			})
+
+			expect(mockFetch).not.toHaveBeenCalled()
+		})
 	})
 
 	describe('query parameter validation', () => {
@@ -282,6 +300,95 @@ describe('beatport/search API', () => {
 	})
 
 	describe('error handling', () => {
+		it('throws 429 error when requests are throttled', async () => {
+			mockGetQuery.mockReturnValue({
+				q: 'Test Artist Test Track',
+				artist: 'Test Artist',
+				title: 'Test Track'
+			})
+
+			mockFetch.mockResolvedValue({
+				ok: true,
+				text: () => Promise.resolve('<html><body></body></html>')
+			})
+
+			await handler({})
+
+			await expect(handler({})).rejects.toMatchObject({
+				statusCode: 429,
+				message: 'Too many requests'
+			})
+
+			expect(mockFetch).toHaveBeenCalledTimes(1)
+		})
+
+		it('throttles by shared IP even across different users', async () => {
+			mockGetQuery.mockReturnValue({
+				q: 'Test Artist Test Track',
+				artist: 'Test Artist',
+				title: 'Test Track'
+			})
+			mockServerSupabaseUser
+				.mockResolvedValueOnce({ id: 'user-1' })
+				.mockResolvedValueOnce({ id: 'user-2' })
+
+			mockFetch.mockResolvedValue({
+				ok: true,
+				text: () => Promise.resolve('<html><body></body></html>')
+			})
+
+			const event = {
+				node: {
+					req: {
+						headers: { 'x-forwarded-for': '203.0.113.5' },
+						socket: { remoteAddress: '203.0.113.5' }
+					}
+				}
+			}
+
+			await handler(event)
+
+			await expect(handler(event)).rejects.toMatchObject({
+				statusCode: 429,
+				message: 'Too many requests'
+			})
+
+			expect(mockFetch).toHaveBeenCalledTimes(1)
+		})
+
+		it('throws 504 error when Beatport request times out', async () => {
+			mockGetQuery.mockReturnValue({
+				q: 'Test Artist Test Track',
+				artist: 'Test Artist',
+				title: 'Test Track'
+			})
+
+			vi.useFakeTimers()
+
+			mockFetch.mockImplementationOnce(
+				(_url: string, options?: { signal?: AbortSignal }) =>
+					new Promise((_resolve, reject) => {
+						options?.signal?.addEventListener('abort', () => {
+							const abortError = new Error('This operation was aborted')
+							abortError.name = 'AbortError'
+							reject(abortError)
+						})
+					})
+			)
+
+			try {
+				const request = handler({})
+				const timeoutExpectation = expect(request).rejects.toMatchObject({
+					statusCode: 504,
+					message: 'Beatport request timed out'
+				})
+				await vi.advanceTimersByTimeAsync(10_000)
+				await timeoutExpectation
+			} finally {
+				vi.useRealTimers()
+			}
+		})
+
 		it('throws 500 error when Beatport returns rate limit (429)', async () => {
 			// Note: The endpoint's catch block converts all fetch-related errors to 500
 			// A future improvement could preserve the original status code

--- a/server/api/beatport/search.get.ts
+++ b/server/api/beatport/search.get.ts
@@ -36,7 +36,28 @@ interface BeatportTrackJSON {
 	track_image_dynamic_uri?: string
 }
 
+interface RateLimitEntry {
+	count: number
+	resetAt: number
+}
+
+const RATE_LIMIT_WINDOW_MS = 1000
+const RATE_LIMIT_MAX_REQUESTS = 1
+const RATE_LIMIT_CLEANUP_INTERVAL_MS = RATE_LIMIT_WINDOW_MS
+const BEATPORT_REQUEST_TIMEOUT_MS = 10_000
+const rateLimitStore = new Map<string, RateLimitEntry>()
+let lastRateLimitCleanupAt = 0
+
 export default defineEventHandler(async (event) => {
+	const user = await serverSupabaseUser(event)
+
+	if (!user) {
+		throw createError({
+			statusCode: 401,
+			statusMessage: 'Authentication required'
+		})
+	}
+
 	const query = getQuery(event)
 	const q = query.q as string
 	const artist = query.artist as string
@@ -56,10 +77,39 @@ export default defineEventHandler(async (event) => {
 		})
 	}
 
+	const clientIp = getClientIp(event)
+	const rateLimitKeys = new Set<string>()
+
+	if (typeof user.id === 'string' && user.id.length > 0) {
+		rateLimitKeys.add(`user:${user.id}`)
+	}
+
+	if (typeof clientIp === 'string' && clientIp.length > 0) {
+		rateLimitKeys.add(`ip:${clientIp}`)
+	}
+
+	if (rateLimitKeys.size === 0) {
+		rateLimitKeys.add('user:unknown')
+	}
+
+	if (isRateLimited(Array.from(rateLimitKeys))) {
+		throw createError({
+			statusCode: 429,
+			statusMessage: 'Too many requests'
+		})
+	}
+
+	const controller = new AbortController()
+	const timeoutId = setTimeout(
+		() => controller.abort(),
+		BEATPORT_REQUEST_TIMEOUT_MS
+	)
+
 	try {
 		const response = await fetch(
 			`https://www.beatport.com/search/tracks?q=${encodeURIComponent(q)}`,
 			{
+				signal: controller.signal,
 				headers: {
 					'User-Agent':
 						'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
@@ -94,13 +144,99 @@ export default defineEventHandler(async (event) => {
 			success: true,
 			data: trackData
 		}
-	} catch {
+	} catch (error) {
+		if (isAbortError(error)) {
+			throw createError({
+				statusCode: 504,
+				statusMessage: 'Beatport request timed out'
+			})
+		}
+
 		throw createError({
 			statusCode: 500,
 			statusMessage: 'Failed to fetch from Beatport'
 		})
+	} finally {
+		clearTimeout(timeoutId)
 	}
 })
+
+function isRateLimited(keys: string[]): boolean {
+	const now = Date.now()
+	pruneExpiredRateLimitEntries(now)
+
+	for (const key of keys) {
+		const existingEntry = rateLimitStore.get(key)
+
+		if (!existingEntry || existingEntry.resetAt <= now) {
+			rateLimitStore.set(key, {
+				count: 1,
+				resetAt: now + RATE_LIMIT_WINDOW_MS
+			})
+			continue
+		}
+
+		existingEntry.count += 1
+		if (existingEntry.count > RATE_LIMIT_MAX_REQUESTS) {
+			return true
+		}
+	}
+
+	return false
+}
+
+function pruneExpiredRateLimitEntries(now: number): void {
+	if (now - lastRateLimitCleanupAt < RATE_LIMIT_CLEANUP_INTERVAL_MS) {
+		return
+	}
+
+	for (const [key, entry] of rateLimitStore) {
+		if (entry.resetAt <= now) {
+			rateLimitStore.delete(key)
+		}
+	}
+
+	lastRateLimitCleanupAt = now
+}
+
+function getClientIp(event: unknown): string | null {
+	const request = (
+		event as {
+			node?: {
+				req?: {
+					headers?: Record<string, string | string[] | undefined>
+					socket?: { remoteAddress?: string | null }
+				}
+			}
+		}
+	).node?.req
+	const forwardedFor = request?.headers?.['x-forwarded-for']
+
+	if (typeof forwardedFor === 'string' && forwardedFor.length > 0) {
+		return forwardedFor.split(',')[0]?.trim() ?? null
+	}
+
+	if (Array.isArray(forwardedFor) && typeof forwardedFor[0] === 'string') {
+		return forwardedFor[0]
+	}
+
+	const remoteAddress = request?.socket?.remoteAddress
+	if (typeof remoteAddress === 'string' && remoteAddress.length > 0) {
+		return remoteAddress
+	}
+
+	return null
+}
+
+function isAbortError(error: unknown): boolean {
+	if (!(error instanceof Error)) {
+		return false
+	}
+
+	return (
+		error.name === 'AbortError' || error.message.toLowerCase().includes('abort')
+	)
+}
 
 function extractTrackDataFromHTML(
 	html: string,

--- a/server/api/beatport/search.get.ts
+++ b/server/api/beatport/search.get.ts
@@ -104,6 +104,7 @@ export default defineEventHandler(async (event) => {
 		() => controller.abort(),
 		BEATPORT_REQUEST_TIMEOUT_MS
 	)
+	const beatportHttpErrors = new WeakSet<Error>()
 
 	try {
 		const response = await fetch(
@@ -124,10 +125,14 @@ export default defineEventHandler(async (event) => {
 		)
 
 		if (!response.ok) {
-			throw createError({
+			const beatportHttpError = createError({
 				statusCode: response.status,
 				statusMessage: `Beatport returned ${response.status}`
 			})
+			if (beatportHttpError instanceof Error) {
+				beatportHttpErrors.add(beatportHttpError)
+			}
+			throw beatportHttpError
 		}
 
 		const html = await response.text()
@@ -150,6 +155,10 @@ export default defineEventHandler(async (event) => {
 				statusCode: 504,
 				statusMessage: 'Beatport request timed out'
 			})
+		}
+
+		if (error instanceof Error && beatportHttpErrors.has(error)) {
+			throw error
 		}
 
 		throw createError({

--- a/server/api/beatport/search.get.ts
+++ b/server/api/beatport/search.get.ts
@@ -45,6 +45,7 @@ const RATE_LIMIT_WINDOW_MS = 1000
 const RATE_LIMIT_MAX_REQUESTS = 1
 const RATE_LIMIT_CLEANUP_INTERVAL_MS = RATE_LIMIT_WINDOW_MS
 const BEATPORT_REQUEST_TIMEOUT_MS = 10_000
+// Process-local in-memory limiter: applies per Node.js process only.
 const rateLimitStore = new Map<string, RateLimitEntry>()
 let lastRateLimitCleanupAt = 0
 
@@ -104,7 +105,6 @@ export default defineEventHandler(async (event) => {
 		() => controller.abort(),
 		BEATPORT_REQUEST_TIMEOUT_MS
 	)
-	const beatportHttpErrors = new WeakSet<Error>()
 
 	try {
 		const response = await fetch(
@@ -125,14 +125,10 @@ export default defineEventHandler(async (event) => {
 		)
 
 		if (!response.ok) {
-			const beatportHttpError = createError({
+			throw createError({
 				statusCode: response.status,
 				statusMessage: `Beatport returned ${response.status}`
 			})
-			if (beatportHttpError instanceof Error) {
-				beatportHttpErrors.add(beatportHttpError)
-			}
-			throw beatportHttpError
 		}
 
 		const html = await response.text()
@@ -157,7 +153,7 @@ export default defineEventHandler(async (event) => {
 			})
 		}
 
-		if (error instanceof Error && beatportHttpErrors.has(error)) {
+		if (isBeatportStatusError(error)) {
 			throw error
 		}
 
@@ -176,7 +172,17 @@ function isRateLimited(keys: string[]): boolean {
 
 	for (const key of keys) {
 		const existingEntry = rateLimitStore.get(key)
+		const nextCount =
+			!existingEntry || existingEntry.resetAt <= now
+				? 1
+				: existingEntry.count + 1
+		if (nextCount > RATE_LIMIT_MAX_REQUESTS) {
+			return true
+		}
+	}
 
+	for (const key of keys) {
+		const existingEntry = rateLimitStore.get(key)
 		if (!existingEntry || existingEntry.resetAt <= now) {
 			rateLimitStore.set(key, {
 				count: 1,
@@ -184,11 +190,7 @@ function isRateLimited(keys: string[]): boolean {
 			})
 			continue
 		}
-
 		existingEntry.count += 1
-		if (existingEntry.count > RATE_LIMIT_MAX_REQUESTS) {
-			return true
-		}
 	}
 
 	return false
@@ -244,6 +246,19 @@ function isAbortError(error: unknown): boolean {
 
 	return (
 		error.name === 'AbortError' || error.message.toLowerCase().includes('abort')
+	)
+}
+
+function isBeatportStatusError(
+	error: unknown
+): error is Error & { statusCode: number } {
+	if (!(error instanceof Error)) {
+		return false
+	}
+
+	return (
+		typeof (error as { statusCode?: unknown }).statusCode === 'number' &&
+		error.message.startsWith('Beatport returned ')
 	)
 }
 

--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -4,4 +4,5 @@ DISCOGS_CONSUMER_KEY=
 DISCOGS_CONSUMER_SECRET=
 DISCOGS_USER_AGENT=CrateGuide/2.0
 
-SITE_URL=http://localhost:3000/
+# Public app absolute URL used to build OAuth callbacks (protocol required, trailing slash optional)
+SITE_URL=http://localhost:3000

--- a/supabase/functions/get-discogs-request-token/index.ts
+++ b/supabase/functions/get-discogs-request-token/index.ts
@@ -15,7 +15,6 @@ const oauth_consumer_key = Deno.env.get('DISCOGS_CONSUMER_KEY') || ''
 const oauth_consumer_secret = Deno.env.get('DISCOGS_CONSUMER_SECRET') || ''
 const userAgent = Deno.env.get('DISCOGS_USER_AGENT') || ''
 const requestTokenURL = 'https://api.discogs.com/oauth/request_token'
-const oauthCallback = `${Deno.env.get('SITE_URL')}auth/discogs/capture-verifier`
 
 Deno.serve(async (req) => {
 	if (req.method === 'OPTIONS') return new Response('ok', { headers })
@@ -24,6 +23,8 @@ Deno.serve(async (req) => {
 	if (!authHeader) return new Response(null, { headers, status: 401 })
 
 	try {
+		const oauthCallback = buildOAuthCallback()
+
 		const params = new URLSearchParams()
 		params.append('oauth_consumer_key', oauth_consumer_key)
 		params.append('oauth_nonce', await generateToken())
@@ -86,3 +87,30 @@ Deno.serve(async (req) => {
 		})
 	}
 })
+
+function buildOAuthCallback() {
+	const siteURL = Deno.env.get('SITE_URL')?.trim()
+	if (!siteURL) {
+		throw new PublicOAuthError(
+			'Server configuration error: SITE_URL is required for Discogs authorization.'
+		)
+	}
+
+	let parsedSiteURL: URL
+	try {
+		parsedSiteURL = new URL(siteURL)
+	} catch {
+		throw new PublicOAuthError(
+			'Server configuration error: SITE_URL must be a valid absolute URL.'
+		)
+	}
+
+	// Preserve any configured base path and make trailing slash optional.
+	parsedSiteURL.pathname = parsedSiteURL.pathname.endsWith('/')
+		? parsedSiteURL.pathname
+		: `${parsedSiteURL.pathname}/`
+	parsedSiteURL.search = ''
+	parsedSiteURL.hash = ''
+
+	return new URL('auth/discogs/capture-verifier', parsedSiteURL).toString()
+}

--- a/supabase/migrations/20260223143000_fix_import_record_with_tracks_auth_uid.sql
+++ b/supabase/migrations/20260223143000_fix_import_record_with_tracks_auth_uid.sql
@@ -1,0 +1,154 @@
+-- SEC-001: prevent tenant escape in import RPC by enforcing caller identity
+CREATE OR REPLACE FUNCTION public.import_record_with_tracks(
+    record JSONB,
+    tracks JSONB DEFAULT '[]'::JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, auth
+AS $$
+DECLARE
+    caller_user_id UUID;
+    inserted_record_id UUID;
+    track_record JSONB;
+    result JSONB;
+BEGIN
+    caller_user_id := auth.uid();
+
+    IF caller_user_id IS NULL THEN
+        RAISE EXCEPTION 'Authentication required';
+    END IF;
+
+    -- Validate that record contains required fields
+    IF record->>'user_id' IS NULL OR record->>'title' IS NULL OR record->'artists' IS NULL OR record->'labels' IS NULL THEN
+        RAISE EXCEPTION 'Missing required fields: user_id, title, artists, and labels are required';
+    END IF;
+
+    -- Never trust client-supplied tenant identity
+    IF (record->>'user_id')::UUID IS DISTINCT FROM caller_user_id THEN
+        RAISE EXCEPTION 'record.user_id must match authenticated user';
+    END IF;
+
+    -- Validate that artists is an array
+    IF jsonb_typeof(record->'artists') != 'array' THEN
+        RAISE EXCEPTION 'artists must be a JSON array';
+    END IF;
+
+    -- Validate that labels is an array
+    IF jsonb_typeof(record->'labels') != 'array' THEN
+        RAISE EXCEPTION 'labels must be a JSON array';
+    END IF;
+
+    -- Validate that tracks is an array
+    IF jsonb_typeof(tracks) != 'array' THEN
+        RAISE EXCEPTION 'tracks must be a JSON array';
+    END IF;
+
+    -- Insert the record
+    INSERT INTO public.records (
+        user_id,
+        discogs_id,
+        discogs_release_url,
+        title,
+        artists,
+        labels,
+        year,
+        cover
+    )
+    VALUES (
+        caller_user_id,
+        CASE WHEN record->>'discogs_id' IS NOT NULL
+              THEN (record->>'discogs_id')::INTEGER
+              ELSE NULL END,
+        record->>'discogs_release_url',
+        record->>'title',
+        record->'artists',
+        record->'labels',
+        CASE WHEN record->>'year' IS NOT NULL
+              THEN (record->>'year')::INTEGER
+              ELSE NULL END,
+        record->>'cover'
+    )
+    RETURNING id INTO inserted_record_id;
+
+    -- Insert tracks if any exist
+    IF jsonb_array_length(tracks) > 0 THEN
+        FOR track_record IN SELECT * FROM jsonb_array_elements(tracks)
+        LOOP
+            -- Validate required track fields
+            IF track_record->>'title' IS NULL THEN
+                RAISE EXCEPTION 'Track title is required';
+            END IF;
+
+            INSERT INTO public.tracks (
+                record_id,
+                title,
+                artists,
+                extraartists,
+                position,
+                duration,
+                bpm,
+                rpm,
+                key,
+                mode,
+                genres,
+                time_signature_upper,
+                time_signature_lower,
+                playable
+            )
+            VALUES (
+                inserted_record_id,
+                track_record->>'title',
+                COALESCE(track_record->'artists', '[]'::jsonb),
+                COALESCE(track_record->'extraartists', '[]'::jsonb),
+                track_record->>'position',
+                CASE WHEN track_record->>'duration' IS NOT NULL
+                      THEN (track_record->>'duration')::INTEGER
+                      ELSE NULL END,
+                CASE WHEN track_record->>'bpm' IS NOT NULL
+                      THEN (track_record->>'bpm')::NUMERIC
+                      ELSE NULL END,
+                CASE WHEN track_record->>'rpm' IS NOT NULL
+                      THEN (track_record->>'rpm')::INTEGER
+                      ELSE NULL END,
+                CASE WHEN track_record->>'key' IS NOT NULL
+                      THEN (track_record->>'key')::SMALLINT
+                      ELSE NULL END,
+                CASE WHEN track_record->>'mode' IS NOT NULL
+                      THEN (track_record->>'mode')::SMALLINT
+                      ELSE NULL END,
+                COALESCE(track_record->'genres', '[]'::jsonb),
+                CASE WHEN track_record->>'time_signature_upper' IS NOT NULL
+                      THEN (track_record->>'time_signature_upper')::SMALLINT
+                      ELSE NULL END,
+                CASE WHEN track_record->>'time_signature_lower' IS NOT NULL
+                      THEN (track_record->>'time_signature_lower')::SMALLINT
+                      ELSE NULL END,
+                CASE WHEN track_record->>'playable' IS NOT NULL
+                      THEN (track_record->>'playable')::BOOLEAN
+                      ELSE TRUE END
+            );
+        END LOOP;
+    END IF;
+
+    -- Return success result with the inserted record data
+    result := jsonb_build_object(
+        'success', true,
+        'record_id', inserted_record_id,
+        'tracks_inserted', jsonb_array_length(tracks)
+    );
+
+    RETURN result;
+EXCEPTION
+    WHEN OTHERS THEN
+        -- Return error result
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', SQLERRM
+        );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.import_record_with_tracks(JSONB, JSONB) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.import_record_with_tracks(JSONB, JSONB) TO authenticated;

--- a/supabase/migrations/20260223143000_fix_import_record_with_tracks_auth_uid.sql
+++ b/supabase/migrations/20260223143000_fix_import_record_with_tracks_auth_uid.sql
@@ -12,7 +12,6 @@ DECLARE
     caller_user_id UUID;
     inserted_record_id UUID;
     track_record JSONB;
-    result JSONB;
 BEGIN
     caller_user_id := auth.uid();
 
@@ -133,20 +132,11 @@ BEGIN
     END IF;
 
     -- Return success result with the inserted record data
-    result := jsonb_build_object(
+    RETURN jsonb_build_object(
         'success', true,
         'record_id', inserted_record_id,
         'tracks_inserted', jsonb_array_length(tracks)
     );
-
-    RETURN result;
-EXCEPTION
-    WHEN OTHERS THEN
-        -- Return error result
-        RETURN jsonb_build_object(
-            'success', false,
-            'error', SQLERRM
-        );
 END;
 $$;
 


### PR DESCRIPTION
## Summary
This PR remediates all issues listed in `docs/tmp/08-repo-audit-2026-02-23.md`:

- `SEC-001` Cross-tenant write in Supabase RPC: enforce `auth.uid()` in `import_record_with_tracks` via migration hardening.
- `SEC-002` Beatport public relay risk: require server-side auth, add per-user/IP rate limiting, and upstream timeout/abort.
- `BUG-001` Beatport status masking: preserve upstream HTTP statuses instead of remapping all to 500.
- `BUG-002` Discogs callback URL brittleness: build callback via URL API and validate `SITE_URL`.
- `QLT-001` Lint red from empty catches: make catch blocks explicit and lint-compliant.
- `QLT-002` Broken staging script env path: point to existing `supabase/functions/.env`.
- `QLT-003` Non-deterministic Vue pinning: replace `latest` with `3.5.28` in dependency + override and sync lockfile.

## Validation
- `npm run lint` ✅
- `npm run test:run` ✅ (28 files, 860 tests)
- Focused endpoint/function tests and checks were also run during implementation review.

## Notes
- Audit docs under `docs/tmp` remain untracked and are not part of this PR.
