### PR TITLE
fix(cleanup): authenticate hosted scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ DISCOGS_USER_AGENT=CrateGuide/2.0
 DISCOGS_RATE_LIMIT_PER_USER=
 DISCOGS_RATE_LIMIT_GLOBAL=
 DISCOGS_RATE_LIMIT_WINDOW_SECONDS=
+ACCOUNT_COVER_CLEANUP_SCHEDULER_SECRET=
 SITE_URL=http://localhost:3000
 ```
 
@@ -356,7 +357,7 @@ prior states and reports if restoration cannot complete. Run
 | `get-discogs-access-token`       | Validates the callback, exchanges/stores credentials, and refreshes public identity.         |
 | `authenticated-discogs-request`  | Dispatches only validated folder, folder-release, and release reads with server signing.     |
 | `cleanup-record-covers`          | Drains durable obsolete-cover jobs for the verified user without accepting client paths.     |
-| `cleanup-orphaned-record-covers` | Processes one bounded, leased account-cover cleanup batch for an exact service-role caller.  |
+| `cleanup-orphaned-record-covers` | Processes one bounded, leased account-cover cleanup batch for an authenticated scheduler.    |
 | `delete-account`                 | Requires recent authentication, schedules durable bounded cleanup, then deletes the account. |
 
 For local emulation, `npm run supa:functions` uses `--no-verify-jwt`; handler

--- a/docs/discogs-integration.md
+++ b/docs/discogs-integration.md
@@ -151,15 +151,16 @@ database function:
 
 ## Environment readers
 
-| Variable                            | Reader / purpose                                               |
-| ----------------------------------- | -------------------------------------------------------------- |
-| `DISCOGS_CONSUMER_KEY`              | `getDiscogsConfig()`; OAuth consumer identifier                |
-| `DISCOGS_CONSUMER_SECRET`           | `getDiscogsConfig()`; server-only OAuth signing secret         |
-| `DISCOGS_USER_AGENT`                | `getDiscogsConfig()`; Discogs API and identity/avatar requests |
-| `DISCOGS_RATE_LIMIT_PER_USER`       | `getDiscogsRateLimitConfig()`; optional per-user quota         |
-| `DISCOGS_RATE_LIMIT_GLOBAL`         | `getDiscogsRateLimitConfig()`; optional shared quota           |
-| `DISCOGS_RATE_LIMIT_WINDOW_SECONDS` | `getDiscogsRateLimitConfig()`; optional quota window           |
-| `SITE_URL`                          | One HTTP(S) origin for CORS and server-built OAuth callbacks   |
+| Variable                                 | Reader / purpose                                               |
+| ---------------------------------------- | -------------------------------------------------------------- |
+| `DISCOGS_CONSUMER_KEY`                   | `getDiscogsConfig()`; OAuth consumer identifier                |
+| `DISCOGS_CONSUMER_SECRET`                | `getDiscogsConfig()`; server-only OAuth signing secret         |
+| `DISCOGS_USER_AGENT`                     | `getDiscogsConfig()`; Discogs API and identity/avatar requests |
+| `DISCOGS_RATE_LIMIT_PER_USER`            | `getDiscogsRateLimitConfig()`; optional per-user quota         |
+| `DISCOGS_RATE_LIMIT_GLOBAL`              | `getDiscogsRateLimitConfig()`; optional shared quota           |
+| `DISCOGS_RATE_LIMIT_WINDOW_SECONDS`      | `getDiscogsRateLimitConfig()`; optional quota window           |
+| `ACCOUNT_COVER_CLEANUP_SCHEDULER_SECRET` | Required dedicated hosted scheduler credential                 |
+| `SITE_URL`                               | One HTTP(S) origin for CORS and server-built OAuth callbacks   |
 
 Shared Supabase helpers also require runtime-provided `SUPABASE_URL`, the
 `default` entry in hosted `SUPABASE_PUBLISHABLE_KEYS`, and the `default` entry
@@ -244,11 +245,16 @@ Account deletion has an additional service-owned recovery path:
   present the current claim token; release retains the row, records a bounded
   attempt count, and applies a short retry delay.
 - `cleanup-orphaned-record-covers` is a POST-only, no-body service endpoint. It
-  accepts only an exact `apikey: <default SUPABASE_SECRET_KEYS value>`
-  credential, compared timing-safely with the server environment value. It has
-  no browser CORS contract, rejects ordinary authenticated and anonymous
-  tokens, accepts no user/path selector, and returns only generic `processed`
-  and `complete` booleans.
+  accepts only an exact scheduler credential, compared timing-safely with the
+  server environment value. Hosted schedulers should use a public project key
+  in `apikey` for the gateway and send the dedicated
+  `ACCOUNT_COVER_CLEANUP_SCHEDULER_SECRET` value in
+  `x-crate-guide-cleanup-secret`. When the dedicated header is absent, the
+  project secret in `apikey` remains a rollout fallback for environments whose
+  gateway accepts it. A present dedicated header never falls through to the
+  `apikey` credential. The endpoint has no browser CORS contract, rejects
+  ordinary authenticated and anonymous tokens, accepts no user/path selector,
+  and returns only generic `processed` and `complete` booleans.
 - One service invocation claims at most one outbox job. A fixed service-only
   database enumeration returns at most 101 exact object names for the claimed
   UUID from `storage.objects`, regardless of folder depth. The worker validates
@@ -270,9 +276,8 @@ Account deletion has an additional service-owned recovery path:
   ordinary caller's already-computed counts or status or expose cross-account
   information.
 - The repository contains no source-controlled hosted schedule for the service
-  endpoint. Its presence supports an operator or future scheduler, but this
-  guide makes no claim that the function is deployed, configured, or scheduled
-  in any hosted project.
+  endpoint. Hosted state and release evidence remain the authority for whether
+  the function is deployed, configured, and scheduled in a specific project.
 - Account-deletion responses distinguish `cover_cleanup_complete` from
   `cleanup_queue_complete`; either false means the account deletion succeeded
   with incomplete cleanup and triggers the same generic client warning.

--- a/docs/staging-release-runbook.md
+++ b/docs/staging-release-runbook.md
@@ -337,6 +337,7 @@ DISCOGS_USER_AGENT=CrateGuide/2.0
 DISCOGS_RATE_LIMIT_PER_USER=45
 DISCOGS_RATE_LIMIT_GLOBAL=55
 DISCOGS_RATE_LIMIT_WINDOW_SECONDS=60
+ACCOUNT_COVER_CLEANUP_SCHEDULER_SECRET=
 SITE_URL=https://crate-guide-staging.pages.dev
 ```
 
@@ -402,11 +403,17 @@ Record an owner and an approved staging cadence. The scheduler must:
 
 - POST an empty body to
   `${SUPABASE_URL}/functions/v1/cleanup-orphaned-record-covers`;
-- source the exact staging secret key from provider-managed Vault or equivalent,
-  never plaintext in `cron.job`, logs, or evidence;
-- send that key only in the `apikey` header;
+- source the exact staging publishable key and a dedicated random scheduler
+  secret from provider-managed Vault or equivalent, never plaintext in
+  `cron.job`, logs, or evidence;
+- send the publishable key in `apikey` and the dedicated secret in
+  `x-crate-guide-cleanup-secret`;
 - accept no caller-selected user ID or Storage path;
 - retain failed/outstanding jobs for retry.
+
+A project secret in `apikey` remains a compatibility fallback only while the
+dedicated header is absent and the hosted gateway accepts that project secret.
+New schedules must use the dedicated-header design.
 
 A one-minute staging cadence is suitable for the multi-page smoke. Record only
 `jobid`, `jobname`, `schedule`, and `active`; do not select or export the command

--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -7,6 +7,11 @@ DISCOGS_RATE_LIMIT_PER_USER=
 DISCOGS_RATE_LIMIT_GLOBAL=
 DISCOGS_RATE_LIMIT_WINDOW_SECONDS=
 
+# Dedicated secret used by the hosted account-cover cleanup scheduler.
+# Keep the public gateway key in `apikey` and send this value only in
+# `x-crate-guide-cleanup-secret`.
+ACCOUNT_COVER_CLEANUP_SCHEDULER_SECRET=
+
 # Public app absolute URL used to build OAuth callbacks (protocol required, trailing slash optional)
 # One absolute HTTP(S) origin only; a trailing slash is accepted.
 SITE_URL=http://localhost:3000

--- a/supabase/functions/cleanup-orphaned-record-covers/handler.test.ts
+++ b/supabase/functions/cleanup-orphaned-record-covers/handler.test.ts
@@ -1,22 +1,31 @@
 import assert from 'node:assert/strict'
 import {
+	ACCOUNT_COVER_CLEANUP_SECRET_HEADER,
 	createCleanupOrphanedRecordCoversHandler,
 	timingSafeSecretEqual
 } from './handler.ts'
 
-const SECRET_KEY = 'sb_secret_test'
+const SCHEDULER_SECRET = 'scheduler-secret-test'
+const PROJECT_SECRET = 'sb_secret_project'
+const PUBLISHABLE_KEY = 'sb_publishable_project'
 
-function request(token = SECRET_KEY, method = 'POST', body?: string): Request {
+function request(
+	token = SCHEDULER_SECRET,
+	method = 'POST',
+	body?: string,
+	headerName = ACCOUNT_COVER_CLEANUP_SECRET_HEADER
+): Request {
 	return new Request('http://localhost', {
 		method,
-		headers: { apikey: token },
+		headers: { [headerName]: token },
 		body
 	})
 }
 
 function dependencies(
 	overrides: {
-		secretKey?: () => string
+		schedulerSecret?: () => string
+		projectSecret?: () => string
 		compareSecrets?: (actual: string, expected: string) => Promise<boolean>
 		processNext?: () => Promise<{
 			processed: boolean
@@ -26,7 +35,8 @@ function dependencies(
 	} = {}
 ) {
 	return {
-		secretKey: overrides.secretKey ?? (() => SECRET_KEY),
+		schedulerSecret: overrides.schedulerSecret ?? (() => SCHEDULER_SECRET),
+		projectSecret: overrides.projectSecret ?? (() => PROJECT_SECRET),
 		compareSecrets: overrides.compareSecrets ?? timingSafeSecretEqual,
 		processNext:
 			overrides.processNext ??
@@ -41,6 +51,7 @@ Deno.test(
 		assert.equal(await timingSafeSecretEqual('same', 'same'), true)
 		assert.equal(await timingSafeSecretEqual('same', 'different'), false)
 		assert.equal(await timingSafeSecretEqual('', 'different'), false)
+		assert.equal(await timingSafeSecretEqual('', ''), false)
 	}
 )
 
@@ -60,7 +71,7 @@ Deno.test('orphan cleanup rejects non-POST methods', async () => {
 		})
 	)
 
-	const response = await handler(request(SECRET_KEY, 'GET'))
+	const response = await handler(request(SCHEDULER_SECRET, 'GET'))
 
 	assert.equal(response.status, 405)
 	assert.equal((await response.json()).code, 'method_not_allowed')
@@ -68,7 +79,7 @@ Deno.test('orphan cleanup rejects non-POST methods', async () => {
 })
 
 Deno.test(
-	'orphan cleanup rejects anon, user, missing, and malformed API keys',
+	'orphan cleanup rejects missing and malformed scheduler secrets',
 	async () => {
 		let didProcess = false
 		const handler = createCleanupOrphanedRecordCoversHandler(
@@ -88,19 +99,132 @@ Deno.test(
 			null,
 			'anon-jwt',
 			'user-jwt',
-			'sb_secret_test extra',
-			'Bearer sb_secret_test'
+			'scheduler-secret-test extra',
+			'Bearer scheduler-secret-test'
 		]
 
 		for (const apiKey of apiKeyValues) {
 			const headers = new Headers()
-			if (apiKey !== null) headers.set('apikey', apiKey)
+			if (apiKey !== null) {
+				headers.set(ACCOUNT_COVER_CLEANUP_SECRET_HEADER, apiKey)
+			}
 			const response = await handler(
 				new Request('http://localhost', { method: 'POST', headers })
 			)
 			assert.equal(response.status, 401)
 			assert.equal((await response.json()).code, 'authentication_required')
 		}
+		assert.equal(didProcess, false)
+	}
+)
+
+Deno.test(
+	'orphan cleanup accepts a public gateway key with the dedicated secret',
+	async () => {
+		const handler = createCleanupOrphanedRecordCoversHandler(
+			{ 'Content-Type': 'application/json' },
+			dependencies()
+		)
+		const headers = new Headers({
+			apikey: PUBLISHABLE_KEY,
+			[ACCOUNT_COVER_CLEANUP_SECRET_HEADER]: SCHEDULER_SECRET
+		})
+
+		const response = await handler(
+			new Request('http://localhost', { method: 'POST', headers })
+		)
+
+		assert.equal(response.status, 200)
+		assert.deepEqual(await response.json(), {
+			processed: false,
+			complete: false
+		})
+	}
+)
+
+Deno.test(
+	'orphan cleanup rejects a public gateway key without the dedicated secret',
+	async () => {
+		const handler = createCleanupOrphanedRecordCoversHandler(
+			{ 'Content-Type': 'application/json' },
+			dependencies()
+		)
+
+		const response = await handler(
+			request(PUBLISHABLE_KEY, 'POST', undefined, 'apikey')
+		)
+
+		assert.equal(response.status, 401)
+		assert.equal((await response.json()).code, 'authentication_required')
+	}
+)
+
+Deno.test(
+	'orphan cleanup retains the project-secret apikey transport fallback',
+	async () => {
+		const handler = createCleanupOrphanedRecordCoversHandler(
+			{ 'Content-Type': 'application/json' },
+			dependencies()
+		)
+
+		const response = await handler(
+			request(PROJECT_SECRET, 'POST', undefined, 'apikey')
+		)
+
+		assert.equal(response.status, 200)
+		assert.deepEqual(await response.json(), {
+			processed: false,
+			complete: false
+		})
+	}
+)
+
+Deno.test(
+	'orphan cleanup prioritises the dedicated secret over apikey',
+	async () => {
+		const handler = createCleanupOrphanedRecordCoversHandler(
+			{ 'Content-Type': 'application/json' },
+			dependencies()
+		)
+		const headers = new Headers({
+			apikey: PROJECT_SECRET,
+			[ACCOUNT_COVER_CLEANUP_SECRET_HEADER]: 'wrong-secret'
+		})
+
+		const response = await handler(
+			new Request('http://localhost', { method: 'POST', headers })
+		)
+
+		assert.equal(response.status, 401)
+		assert.equal((await response.json()).code, 'authentication_required')
+	}
+)
+
+Deno.test(
+	'orphan cleanup fails closed when the dedicated secret is unavailable',
+	async () => {
+		let didProcess = false
+		const handler = createCleanupOrphanedRecordCoversHandler(
+			{ 'Content-Type': 'application/json' },
+			dependencies({
+				schedulerSecret: () => {
+					throw new Error('missing scheduler secret')
+				},
+				processNext: () => {
+					didProcess = true
+					return Promise.resolve({
+						processed: false,
+						complete: false,
+						failed: false
+					})
+				}
+			})
+		)
+
+		const response = await handler(request())
+
+		assert.equal(response.status, 503)
+		assert.equal((await response.json()).code, 'service_unavailable')
 		assert.equal(didProcess, false)
 	}
 )
@@ -122,7 +246,7 @@ Deno.test('orphan cleanup rejects every request body', async () => {
 	)
 
 	const response = await handler(
-		request(SECRET_KEY, 'POST', JSON.stringify({ user_id: 'forbidden' }))
+		request(SCHEDULER_SECRET, 'POST', JSON.stringify({ user_id: 'forbidden' }))
 	)
 
 	assert.equal(response.status, 400)

--- a/supabase/functions/cleanup-orphaned-record-covers/handler.ts
+++ b/supabase/functions/cleanup-orphaned-record-covers/handler.ts
@@ -2,16 +2,21 @@ import {
 	type AccountCoverCleanupResult,
 	processNextAccountCoverCleanup
 } from '../_shared/accountCoverCleanup.ts'
-import { requireSecretKey } from '../_shared/supabaseHelpers.ts'
+import { requireEnv, requireSecretKey } from '../_shared/supabaseHelpers.ts'
+
+export const ACCOUNT_COVER_CLEANUP_SECRET_HEADER =
+	'x-crate-guide-cleanup-secret'
 
 interface HandlerDependencies {
-	secretKey(): string
+	schedulerSecret(): string
+	projectSecret(): string
 	compareSecrets(actual: string, expected: string): Promise<boolean>
 	processNext(): Promise<AccountCoverCleanupResult>
 }
 
 const defaultDependencies: HandlerDependencies = {
-	secretKey: requireSecretKey,
+	schedulerSecret: () => requireEnv('ACCOUNT_COVER_CLEANUP_SCHEDULER_SECRET'),
+	projectSecret: requireSecretKey,
 	compareSecrets: timingSafeSecretEqual,
 	processNext: () => processNextAccountCoverCleanup()
 }
@@ -28,6 +33,8 @@ export async function timingSafeSecretEqual(
 	actual: string,
 	expected: string
 ): Promise<boolean> {
+	if (!actual || !expected) return false
+
 	const encoder = new TextEncoder()
 	const [actualDigest, expectedDigest] = await Promise.all([
 		crypto.subtle.digest('SHA-256', encoder.encode(actual)),
@@ -57,9 +64,18 @@ export function createCleanupOrphanedRecordCoversHandler(
 
 		let isSecretKey: boolean
 		try {
+			const dedicatedSecret = request.headers.get(
+				ACCOUNT_COVER_CLEANUP_SECRET_HEADER
+			)
+			const suppliedSecret =
+				dedicatedSecret ?? request.headers.get('apikey') ?? ''
+			const expectedSecret =
+				dedicatedSecret === null
+					? dependencies.projectSecret()
+					: dependencies.schedulerSecret()
 			isSecretKey = await dependencies.compareSecrets(
-				request.headers.get('apikey') ?? '',
-				dependencies.secretKey()
+				suppliedSecret,
+				expectedSecret
 			)
 		} catch {
 			return jsonResponse(


### PR DESCRIPTION
## Summary

- split the public gateway key from the dedicated cleanup scheduler credential
- preserve the existing project-secret `apikey` transport only as an explicit compatibility fallback
- fail closed on missing, empty, or conflicting scheduler credentials
- document the Vault-backed hosted schedule contract

## Verification

- `npm run verify`
- focused cleanup handler tests: 11 passed
- independent security review: no remaining blocker

## Production context

Production new secret keys are not accepted by the Functions gateway on this project, while publishable keys are. This change lets the gateway authenticate the public key and the handler independently authenticate a dedicated scheduler secret without plaintext in cron.