### PR TITLE
docs(release): record production rollout

### DIFF
--- a/docs/release-evidence/2026-07-31-0825fb9-production.md
+++ b/docs/release-evidence/2026-07-31-0825fb9-production.md
@@ -1,0 +1,247 @@
+# Production release evidence: `0825fb9`
+
+- Release date: 2026-07-31 (Australia/Melbourne)
+- Application SHA: `0825fb9474dee72fe0b8d881fe043529768923ea`
+- Integration pull request:
+  [#10](https://github.com/ryan-voitiskis/crate-guide/pull/10)
+- Scheduler authentication pull request:
+  [#11](https://github.com/ryan-voitiskis/crate-guide/pull/11)
+- Release:
+  [`v2.0.0-beta.3`](https://github.com/ryan-voitiskis/crate-guide/releases/tag/v2.0.0-beta.3)
+- Disposition: **released to production**
+
+## Decision and boundaries
+
+Promote the verified application, database, Edge Functions, Auth configuration,
+and account-cover cleanup scheduler to production. The release retains Discogs
+acquisition as a core signed-in feature.
+
+This release does not include accountless or offline mode. The Discogs
+portability decision and provider inquiry remain deferred. No provider
+communication was sent, no live production Discogs OAuth flow was completed,
+and no transactional email was sent during the rollout.
+
+## Exact-head verification
+
+- Pull request #11 passed hosted GitHub `Verify` run
+  [30557180427](https://github.com/ryan-voitiskis/crate-guide/actions/runs/30557180427)
+  at exact head `8aedd5488a3831df6cd063759615483ca575a19a`.
+  The unchanged retry passed after the first hosted runner exceeded the
+  100,000-track Rekordbox XML timing budget by 266.1 milliseconds. No
+  implementation or performance threshold was changed.
+- The merge commit has the same Git tree as the verified pull-request head.
+- Merged `main` passed hosted GitHub `Verify` run
+  [30558548421](https://github.com/ryan-voitiskis/crate-guide/actions/runs/30558548421)
+  at exact head `0825fb9474dee72fe0b8d881fe043529768923ea`.
+- Both exact-head runs passed application and database jobs, including
+  dependency topology, production/all/frozen-Edge audits, browser matrix, full
+  application verification, production build, built security headers, client
+  bundle budget, pgTAP, and generated-type/schema parity.
+- A clean detached worktree at the merge SHA, using Node `24.18.1` and npm
+  `11.16.0`, passed the production build, built browser security-header check,
+  and client-bundle budget.
+- The final local application verification passed 157 test files / 2,445
+  application tests, 22 E2E passes plus one intentional skip, 81 browser tests,
+  and 146 Edge tests. The database job passed 13 pgTAP files / 463 assertions.
+- The production artifact contains only the production Supabase reference and
+  contains no staging Supabase reference.
+- Initial JavaScript is 1,097,413 raw bytes / 351,339 gzip bytes. The largest
+  ordinary chunk is 127,476 raw / 36,752 gzip. Worker, WASM, CSS, and lazy
+  boundaries remain within the checked-in budget.
+
+## Dependency maintenance
+
+- Every installed dependency is at the newest version allowed by the reviewed
+  package ranges, and the production, complete, and frozen Edge dependency
+  audits report zero vulnerabilities.
+- Clean installation permits only reviewed lifecycle scripts. Optional
+  `fsevents` scripts remain denied by name.
+- The remaining install warning is the transitive `glob@10.5.0` deprecation
+  through `@vue/test-utils` and `js-beautify`; it is not a direct dependency and
+  has no current npm advisory.
+- Breaking upgrade tracks remain deliberate follow-up work: Pinia 4 and its
+  Nuxt/testing adapters, Playwright 1.62 browser recertification,
+  `prettier-plugin-tailwindcss` 0.8, TypeScript 7, and Zod 4.
+
+## Backup and rollback evidence
+
+The provider backup listing exposed no available production restore point, so a
+manual logical backup was captured before the database migration:
+
+| Artifact                     | SHA-256                                                            |
+| ---------------------------- | ------------------------------------------------------------------ |
+| Roles                        | `4350a72b5ec109888e740c17f3eb4da2fcd95ab73af26499538ed0bf615db543` |
+| Public schema                | `91e4b7d4735ffc2002674c505af8f239eca2ea21e4da2960ee5750ab3d40096e` |
+| Public data                  | `dce82b703a1e0dd3af9a575067e9d310009193cfd6126eec271dd149f61c0a28` |
+| Migration-history schema     | `18b99fbbb3ec9fbb964bb255a56171329acd99b6977ece2addd89fdf5aa5105b` |
+| Migration-history data       | `7357b756bcd3b6495378984fa29af9ddb4cd14e1a3fcf610ddada2657e1d5512` |
+| Auth/storage change evidence | `d56551a02542b54c30b08968bb5d0f2b41dc4ae8d0fc91cf992e1585586b6937` |
+
+The backup restored successfully into a disposable local PostgreSQL 15
+environment. Restored counts were one Auth user, one profile, 180 records, 759
+tracks, and zero crates, sets, storage objects, or orphan tracks. The coherent
+snapshot contract also passed. The disposable restore was reset afterward so
+production data did not remain in the local database.
+
+Storage contained zero objects at the checkpoint, so there was no binary object
+payload to back up.
+
+Rollback and containment controls are:
+
+- do not apply down migrations; use a reviewed forward fix or restore from the
+  verified logical backup;
+- disable a malfunctioning cleanup schedule with `cron.alter_job` while
+  preserving durable queues and Vault entries;
+- the previous Pages deployment is
+  `4ebc9163-4beb-4bc8-825d-5c8ff25068fa` at source `841f6a7`, but do not use an
+  application-only rollback after incompatible Evidence v2 data is written;
+- prefer an exact-head forward fix for application or Edge regressions.
+
+## Database deployment and compatibility
+
+The following six reviewed migrations are applied and aligned with production
+migration history:
+
+- `20260722140000`
+- `20260722200000`
+- `20260722210000`
+- `20260722220000`
+- `20260723100000`
+- `20260730140000`
+
+Post-migration constraint, privilege, RLS, RPC, receipt, cleanup, and Evidence
+v2 guard checks passed.
+
+Before the new application deployment, a rollback-only transaction exercised
+the migrated schema as the existing production user. It covered profile and
+settings reads, records, tracks, crates, sets, legacy empty-array crate
+insert/edit, membership add/remove, saved-set create/reload/delete, and
+disposable record creation plus atomic removal and reference cleanup. The
+transaction ended with an explicit `ROLLBACK`.
+
+The production data checkpoint was identical before and after migration,
+compatibility, scheduler, and application checks:
+
+| Resource                          | Count |
+| --------------------------------- | ----: |
+| Auth users                        |     1 |
+| Profiles                          |     1 |
+| Records                           |   180 |
+| Tracks                            |   759 |
+| Crates                            |     0 |
+| Sets                              |     0 |
+| Storage objects                   |     0 |
+| Ordinary cover-cleanup jobs       |     0 |
+| Account cover-cleanup outbox rows |     0 |
+| Enrichment receipts               |     0 |
+| Evidence write guards             |     0 |
+| Evidence v2 tracks                |     0 |
+| Orphan tracks                     |     0 |
+
+This production checkpoint validates the database contract without exposing
+personal identifiers. The authenticated hosted UI and Evidence v2 mutation
+flows were previously exercised with disposable accounts on isolated staging;
+no real production library row was mutated for release testing.
+
+## Edge Functions, Auth, and scheduler
+
+All six production Edge Functions are active with internal caller verification:
+
+- `authenticated-discogs-request` version 6;
+- `get-discogs-request-token` version 6;
+- `get-discogs-access-token` version 6;
+- `delete-account` version 6;
+- `cleanup-record-covers` version 4; and
+- `cleanup-orphaned-record-covers` version 6.
+
+All six reject unauthenticated POST requests before provider or cleanup work.
+The five browser-facing Functions return the exact production CORS origin. The
+scheduler-only orphan cleanup Function rejects non-POST methods with `405`.
+
+Production Auth has:
+
+- Site URL `https://crate.guide`;
+- redirect allow-list entries only for the password-update and auth-finalising
+  routes on `https://crate.guide`;
+- anonymous sign-in disabled;
+- sign-up enabled; and
+- automatic email confirmation disabled.
+
+`pg_cron` `1.6.4`, `pg_net` `0.20.3`, and `supabase_vault` `0.3.1` are installed.
+The active `crate-guide-production-account-cover-cleanup` job runs once per
+minute and:
+
+- reads the project URL, default publishable key, and a distinct cleanup
+  scheduler secret from Vault;
+- sends the publishable key in `apikey`;
+- sends the dedicated secret in `x-crate-guide-cleanup-secret`;
+- sends no `Authorization` header and no request body; and
+- contains no literal project credential.
+
+The matching scheduler secret is stored in the Edge environment and the
+operator Keychain. A hosted call with the correct dedicated credential returned
+HTTP `200` with an empty-queue no-work result. A valid gateway key with an
+incorrect dedicated secret returned `401 authentication_required`, proving the
+custom-header path cannot fall through to the compatibility credential.
+
+Three successive scheduled executions completed with:
+
+- cron status `succeeded`;
+- HTTP status `200`;
+- no timeout or network error;
+- `processed: false` and `complete: false`; and
+- both cleanup queues still empty.
+
+The older production cleanup-secret Vault entry remains unused and available
+for rollback diagnosis; the active schedule references only the new dedicated
+credential.
+
+## Pages deployment and hosted application
+
+- Cloudflare Pages project: `crate-guide`
+- Production branch: `main`
+- Stable origin: <https://crate.guide>
+- Deployment:
+  `4167970f-a853-4fea-9eb4-7a3fb077dacb`
+  (<https://4167970f.crate-guide.pages.dev>)
+- Cloudflare source: `0825fb9`
+
+The stable origin and one-off deployment returned byte-identical application
+HTML for `/` and an SPA fallback route. Both passed the repository's exact
+hosted assertions for containment CSP, report-only CSP, production-only
+Supabase HTTP/WSS origins, Discogs image origin, HSTS, frame denial, MIME
+sniffing denial, restrictive permissions, and absence of `x-powered-by`.
+
+A fresh signed-out browser session verified:
+
+- `/records` redirects to `/login` while retaining the intended return path;
+- the access console renders its email, password, provider, sign-up, reset, and
+  read-only demo controls;
+- the public demo renders the library workbench and sample records/tracks; and
+- no browser runtime errors were reported.
+
+No production password recovery, confirmation email, provider OAuth, or
+authenticated browser mutation was triggered during the rollout.
+
+## Security-advisor disposition
+
+The post-release production security-advisor result contains no ERROR-level
+finding. It contains six INFO and eight WARN results:
+
+- six private RLS-enabled tables intentionally have no browser policy;
+- seven reviewed `SECURITY DEFINER` RPCs remain executable by `authenticated`
+  because they enforce the intended mutation boundary; and
+- leaked-password protection remains disabled.
+
+Enabling leaked-password protection is an explicit maintenance follow-up. It is
+not represented as closed by this release.
+
+## Final release state
+
+`v2.0.0-beta.3` is published from the exact production SHA. Production Pages,
+database history, Edge Functions, Auth configuration, and the cleanup scheduler
+are healthy at the recorded checkpoints.
+
+Discogs acquisition remains enabled. Provider portability, provider inquiry,
+accountless/offline mode, production provider OAuth, and transactional-email
+testing remain outside this release.


### PR DESCRIPTION
## What changed

Adds sanitized, source-controlled evidence for the `v2.0.0-beta.3` production
rollout.

The record covers exact application and scheduler SHAs, GitHub verification
runs, dependency maintenance, backup hashes and restore proof, database
migrations and invariant counts, Edge/Auth/scheduler configuration, Cloudflare
Pages deployment, hosted smoke results, rollback controls, and deliberately
unexercised provider/email/accountless boundaries.

## Why

The production deployment is complete, but the release needs durable repository
evidence that distinguishes verified implementation, hosted production state,
rollback material, and remaining follow-ups without storing credentials or
personal identifiers.

## Impact

Documentation only. The deployed production artifact remains
`0825fb9474dee72fe0b8d881fe043529768923ea`; this PR does not redeploy Pages,
mutate Supabase, contact Discogs, or send email.

## Validation

- `npm run format`
- `npm run check:conventions`
- `npm run verify`
- `git diff --cached --check`
- credential/identity pattern scan of the evidence file
