### PR TITLE
docs(release): correct function versions

### DIFF
--- a/docs/release-evidence/2026-07-31-0825fb9-production.md
+++ b/docs/release-evidence/2026-07-31-0825fb9-production.md
@@ -147,11 +147,11 @@ no real production library row was mutated for release testing.
 
 All six production Edge Functions are active with internal caller verification:
 
-- `authenticated-discogs-request` version 6;
-- `get-discogs-request-token` version 6;
-- `get-discogs-access-token` version 6;
-- `delete-account` version 6;
-- `cleanup-record-covers` version 4; and
+- `authenticated-discogs-request` version 7;
+- `get-discogs-request-token` version 7;
+- `get-discogs-access-token` version 7;
+- `delete-account` version 7;
+- `cleanup-record-covers` version 5; and
 - `cleanup-orphaned-record-covers` version 6.
 
 All six reject unauthenticated POST requests before provider or cleanup work.


### PR DESCRIPTION
## Summary

- correct the final deployed Edge Function version numbers in the production release evidence
- retain the exact live values observed in the post-release audit

## Verification

- `npm run format`
- `npm run check:conventions`
- `npm run verify`
- production `supabase functions list` re-fetch