### PR TITLE
fix(enrichment): contain evidence status labels

### DIFF
--- a/app/components/enrichment/TableTrackEnrichmentReview.vue
+++ b/app/components/enrichment/TableTrackEnrichmentReview.vue
@@ -301,7 +301,7 @@ function getEvidenceText(row: TrackEnrichmentRow): string {
 					class="bg-muted/70 sticky top-0 z-10 shadow-[0_1px_0_var(--border)] backdrop-blur-md [&_th]:h-8 [&_th]:font-mono [&_th]:text-[9px] [&_th]:tracking-wide [&_th]:uppercase"
 				>
 					<TableRow>
-						<TableHead class="w-24">
+						<TableHead class="w-28">
 							<div class="flex items-center gap-2">
 								<CheckboxLargeHitArea
 									:model-value="filteredSelectionState"
@@ -394,7 +394,7 @@ function getEvidenceText(row: TrackEnrichmentRow): string {
 								<div class="min-w-0">
 									<div
 										v-if="getStageLabel(row)"
-										class="font-mono text-[9px] font-semibold tracking-wide uppercase"
+										class="font-mono text-[9px] leading-tight font-semibold tracking-wide whitespace-normal uppercase"
 										:class="getStageClasses(row)"
 									>
 										{{ getStageLabel(row) }}

--- a/test/nuxt/TableTrackEnrichmentReview.nuxt.test.ts
+++ b/test/nuxt/TableTrackEnrichmentReview.nuxt.test.ts
@@ -183,6 +183,22 @@ describe('TableTrackEnrichmentReview', () => {
 		)
 	})
 
+	it('reserves wrapping space for evidence-only desktop statuses', async () => {
+		const wrapper = await mountTable([
+			createRow({ canFillBpm: false, canFillKeyMode: false })
+		])
+		const desktopTable = wrapper.get(
+			'[data-testid="enrichment-review-desktop-table"]'
+		)
+		const stageLabel = desktopTable.get('tbody td').get('.whitespace-normal')
+
+		expect(desktopTable.get('thead th').classes()).toContain('w-28')
+		expect(stageLabel.text().trim()).toBe('Evidence only')
+		expect(stageLabel.classes()).toEqual(
+			expect.arrayContaining(['leading-tight', 'whitespace-normal'])
+		)
+	})
+
 	it('omits unavailable labels for non-stageable rows in mixed views', async () => {
 		const wrapper = await mountTable([
 			createRow({


### PR DESCRIPTION
## What changed

- widen the desktop enrichment Stage column from 96px to 112px
- allow compact status labels such as `Evidence only` and `Evidence staged` to wrap with tight line spacing
- add a Nuxt regression test for the desktop Evidence-only geometry contract

## Why

The shared table cell applies `white-space: nowrap`. After the Evidence-only workflow shipped, the Stage column left only about 40px beside its checkbox, causing the label to overlap the Crate Guide match column.

## Impact

Evidence statuses now remain contained in the Stage column while preserving the dense workbench layout. Match Quality gives up only 16px.

## Validation

- `npm run check:conventions`
- `npm run verify`
- focused Nuxt test: 8/8 passed
- local browser measurement at 1422px: 112px Stage cell, two 11.25px lines, label inside the cell boundary
