### PR TITLE
fix: address four production audit defects

### DIFF
--- a/app/components/enrichment/PageTrackEnrichment.vue
+++ b/app/components/enrichment/PageTrackEnrichment.vue
@@ -48,6 +48,10 @@ let recordDraftApplyAttempt = async (
 	_attempt: TrackEnrichmentApplyAttempt
 ) => {}
 const workflow = useTrackEnrichmentWorkflow({
+	captureApplyGuard: () => {
+		const { context } = runtime.capture()
+		return () => runtime.isCurrent(context)
+	},
 	records,
 	tracks,
 	onApplyAttempt: (attempt) => recordDraftApplyAttempt(attempt)
@@ -194,11 +198,15 @@ if (import.meta.client) {
 	useEventListener(window, 'beforeunload', handleBeforeUnload)
 }
 
+function cancelPendingWork() {
+	cancelParsing()
+	workflow.cancelPendingApply()
+}
 watch(isActive, (active) => {
-	if (!active) cancelParsing()
+	if (!active) cancelPendingWork()
 })
-onDeactivated(cancelParsing)
-onBeforeUnmount(cancelParsing)
+onDeactivated(cancelPendingWork)
+onBeforeUnmount(cancelPendingWork)
 
 onMounted(async () => {
 	const results = await Promise.all([

--- a/app/components/records/DialogTrackEdit.vue
+++ b/app/components/records/DialogTrackEdit.vue
@@ -3,6 +3,9 @@ import { toast } from 'vue-sonner'
 import { toTypedSchema } from '@vee-validate/zod'
 import { useForm } from 'vee-validate'
 import {
+	type TrackEditorBaseline,
+	buildTrackEditorPatch,
+	createTrackEditorBaseline,
 	buildTrackEditorPayload,
 	createTrackEditorInitialValues,
 	hasTrackEditorChanges,
@@ -30,6 +33,27 @@ const extraartists = ref<DiscogsArtistDb[]>([])
 
 const showUnsavedChangesAlert = ref(false)
 const isSubmitting = ref(false)
+const editBaseline = shallowRef<TrackEditorBaseline | null>(null)
+const editConflict = shallowRef<{ latest: TrackEditorBaseline | null } | null>(
+	null
+)
+
+function reviewLatestTrack() {
+	const latest = editConflict.value?.latest
+	if (!latest || !editBaseline.value) return
+	const parsed = trackEditorSchema.safeParse(values)
+	if (!parsed.success) return
+	const edits = buildTrackEditorPatch(
+		editBaseline.value.payload,
+		buildTrackEditorPayload(parsed.data, artists.value, extraartists.value)
+	)
+	const reviewed = { ...latest.payload, ...edits }
+	editBaseline.value = latest
+	setValues(trackToEditorValues(reviewed))
+	artists.value = reviewed.artists.map((artist) => ({ ...artist }))
+	extraartists.value = reviewed.extraartists.map((artist) => ({ ...artist }))
+	editConflict.value = null
+}
 const showValidationErrors = ref(false)
 let nextSubmissionId = 0
 let activeSubmissionId: number | null = null
@@ -73,6 +97,8 @@ watch(
 	([generation, track, isOpen, editing]) => {
 		if (generation !== initializedDialogGeneration) {
 			initializedDialogGeneration = generation
+			editBaseline.value = null
+			editConflict.value = null
 			isFormInitialized.value = false
 			showUnsavedChangesAlert.value = false
 			showValidationErrors.value = false
@@ -84,10 +110,12 @@ watch(
 
 		if (track && isOpen && editing && !isFormInitialized.value) {
 			// Editing existing track
+			editBaseline.value = createTrackEditorBaseline(track)
+			editConflict.value = null
 			setValues(trackToEditorValues(track))
 			// Set artists independently
-			artists.value = [...track.artists]
-			extraartists.value = [...track.extraartists]
+			artists.value = track.artists.map((artist) => ({ ...artist }))
+			extraartists.value = track.extraartists.map((artist) => ({ ...artist }))
 			isFormInitialized.value = true
 		} else if (isOpen && !editing && !isFormInitialized.value) {
 			// Opening for new track - reset form
@@ -109,11 +137,11 @@ watch(
 )
 
 function hasFormChanges(): boolean {
-	if (!editingTrack.value || !isEditing.value || !isFormInitialized.value)
+	if (!editBaseline.value || !isEditing.value || !isFormInitialized.value)
 		return false
 
 	return hasTrackEditorChanges(
-		editingTrack.value,
+		editBaseline.value.payload,
 		values,
 		artists.value,
 		extraartists.value
@@ -129,6 +157,7 @@ function handleCloseDialog() {
 }
 
 const submitTrack = handleSubmit(async (values) => {
+	if (isSubmitting.value || editConflict.value) return
 	const recordId = selectedRecordId.value
 	if (!recordId) {
 		toast.error('Record ID is required to save track')
@@ -160,7 +189,21 @@ const submitTrack = handleSubmit(async (values) => {
 
 		if (editing && trackId) {
 			// Update existing track
-			const result = await tracks.updateTrack(trackId, payload)
+			const baseline = editBaseline.value
+			if (!baseline || baseline.id !== trackId) return
+			const result = await tracks.updateTrack(
+				trackId,
+				buildTrackEditorPatch(baseline.payload, payload),
+				{
+					expectedUpdatedAt: baseline.updatedAt,
+					onConflict: (current) => {
+						if (ownsActiveDialog())
+							editConflict.value = {
+								latest: current ? createTrackEditorBaseline(current) : null
+							}
+					}
+				}
+			)
 			if (result && ownsActiveDialog()) {
 				toast.success('Track updated successfully')
 				resetSubmissionState()
@@ -227,6 +270,13 @@ function confirmDiscardAndProceed() {
 			</DialogHeader>
 
 			<div class="-mx-6 space-y-6 overflow-y-auto px-6" tabindex="-1">
+				<NoticeTrackEditConflict
+					v-if="editConflict && editBaseline"
+					:baseline="editBaseline.payload"
+					:latest="editConflict.latest?.payload ?? null"
+					:key-format="preferences.currentKeyFormat"
+					@review="reviewLatestTrack"
+				/>
 				<FormTrackEditorFields
 					v-model:artists="artists"
 					v-model:extraartists="extraartists"
@@ -238,7 +288,11 @@ function confirmDiscardAndProceed() {
 					class="flex flex-col justify-end gap-2 pt-0 max-sm:px-2 sm:flex-row"
 				>
 					<Button variant="secondary" @click="handleCancel">Cancel</Button>
-					<ButtonLoading :loading="isSubmitting" @click="saveTrack">
+					<ButtonLoading
+						:loading="isSubmitting"
+						:disabled="!!editConflict"
+						@click="saveTrack"
+					>
 						{{ isEditing ? 'Update Track' : 'Add Track' }}
 					</ButtonLoading>
 				</div>

--- a/app/components/tracks/DialogTrackDetails.vue
+++ b/app/components/tracks/DialogTrackDetails.vue
@@ -3,6 +3,9 @@ import { Pencil, PencilOff } from '@lucide/vue'
 import { toTypedSchema } from '@vee-validate/zod'
 import { useForm } from 'vee-validate'
 import {
+	type TrackEditorBaseline,
+	buildTrackEditorPatch,
+	createTrackEditorBaseline,
 	buildTrackEditorPayload,
 	createTrackEditorInitialValues,
 	hasTrackEditorChanges,
@@ -27,6 +30,27 @@ const isEditMode = ref(false)
 const showUnsavedChangesAlert = ref(false)
 const isFormInitialized = ref(false)
 const isSubmitting = ref(false)
+const editBaseline = shallowRef<TrackEditorBaseline | null>(null)
+const editConflict = shallowRef<{ latest: TrackEditorBaseline | null } | null>(
+	null
+)
+
+function reviewLatestTrack() {
+	const latest = editConflict.value?.latest
+	if (!latest || !editBaseline.value) return
+	const parsed = trackEditorSchema.safeParse(values)
+	if (!parsed.success) return
+	const edits = buildTrackEditorPatch(
+		editBaseline.value.payload,
+		buildTrackEditorPayload(parsed.data, artists.value, extraartists.value)
+	)
+	const reviewed = { ...latest.payload, ...edits }
+	editBaseline.value = latest
+	setValues(trackToEditorValues(reviewed))
+	artists.value = reviewed.artists.map((artist) => ({ ...artist }))
+	extraartists.value = reviewed.extraartists.map((artist) => ({ ...artist }))
+	editConflict.value = null
+}
 let detailsGeneration = 0
 let nextSubmissionId = 0
 let activeSubmissionId: number | null = null
@@ -38,6 +62,8 @@ function resetSubmissionState() {
 
 function advanceDetailsGeneration() {
 	detailsGeneration += 1
+	editBaseline.value = null
+	editConflict.value = null
 	resetSubmissionState()
 	isFormInitialized.value = false
 }
@@ -94,9 +120,11 @@ watch(
 	[() => selectedTrack.value, () => isEditMode.value],
 	([track, editMode]) => {
 		if (track && editMode && !isFormInitialized.value) {
+			editBaseline.value = createTrackEditorBaseline(track)
+			editConflict.value = null
 			setValues(trackToEditorValues(track))
-			artists.value = [...track.artists]
-			extraartists.value = [...track.extraartists]
+			artists.value = track.artists.map((artist) => ({ ...artist }))
+			extraartists.value = track.extraartists.map((artist) => ({ ...artist }))
 			isFormInitialized.value = true
 		} else if (!editMode) {
 			isFormInitialized.value = false
@@ -108,11 +136,11 @@ watch(
 )
 
 function hasFormChanges(): boolean {
-	if (!selectedTrack.value || !isEditMode.value || !isFormInitialized.value)
+	if (!editBaseline.value || !isEditMode.value || !isFormInitialized.value)
 		return false
 
 	return hasTrackEditorChanges(
-		selectedTrack.value,
+		editBaseline.value.payload,
 		values,
 		artists.value,
 		extraartists.value
@@ -136,6 +164,7 @@ function handleToggleEditMode() {
 }
 
 const saveTrack = handleSubmit(async (values) => {
+	if (isSubmitting.value || editConflict.value) return
 	const trackId = props.trackId
 	if (!trackId || selectedTrack.value?.id !== trackId) return
 	const submissionGeneration = detailsGeneration
@@ -156,7 +185,21 @@ const saveTrack = handleSubmit(async (values) => {
 	)
 
 	try {
-		const result = await tracks.updateTrack(trackId, updates)
+		const baseline = editBaseline.value
+		if (!baseline || baseline.id !== trackId) return
+		const result = await tracks.updateTrack(
+			trackId,
+			buildTrackEditorPatch(baseline.payload, updates),
+			{
+				expectedUpdatedAt: baseline.updatedAt,
+				onConflict: (current) => {
+					if (ownsActiveEditor())
+						editConflict.value = {
+							latest: current ? createTrackEditorBaseline(current) : null
+						}
+				}
+			}
+		)
 		if (result && ownsActiveEditor()) {
 			resetSubmissionState()
 			setEditMode(false)
@@ -239,6 +282,13 @@ function formatKey(track: LibraryTrack): string {
 						</Button>
 					</div>
 
+					<NoticeTrackEditConflict
+						v-if="editConflict && editBaseline"
+						:baseline="editBaseline.payload"
+						:latest="editConflict.latest?.payload ?? null"
+						:key-format="preferences.currentKeyFormat"
+						@review="reviewLatestTrack"
+					/>
 					<FormTrackEditorFields
 						v-if="isEditMode"
 						v-model:artists="artists"
@@ -375,7 +425,7 @@ function formatKey(track: LibraryTrack): string {
 							Cancel
 						</Button>
 						<ButtonLoading
-							:disabled="!meta.valid"
+							:disabled="!meta.valid || !!editConflict"
 							:loading="isSubmitting"
 							@click="saveTrack"
 						>

--- a/app/components/tracks/NoticeTrackEditConflict.vue
+++ b/app/components/tracks/NoticeTrackEditConflict.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { getFormattedKeyString } from '~/utils/keyFunctions'
+import { msToMMSS } from '~/utils/formatting'
+import type { TrackEditorPayload } from '~/utils/trackEditor'
+import type { LibraryKeyFormat } from '~~/shared/types/library'
+
+const props = defineProps<{
+	baseline: TrackEditorPayload
+	latest: TrackEditorPayload | null
+	keyFormat: LibraryKeyFormat
+}>()
+defineEmits<{ review: [] }>()
+
+const changedValues = computed(() => {
+	if (!props.latest) return []
+	const describe = (value: TrackEditorPayload) => ({
+		Title: value.title,
+		Artists: value.artists.map((artist) => artist.name).join(', '),
+		Credits: value.extraartists
+			.map(
+				(artist) => `${artist.name}${artist.role ? ` (${artist.role})` : ''}`
+			)
+			.join(', '),
+		Position: value.position,
+		Duration: msToMMSS(value.duration),
+		BPM: value.bpm,
+		RPM: value.rpm,
+		Key:
+			value.key !== null && value.mode !== null
+				? getFormattedKeyString(value.key, value.mode, props.keyFormat)
+				: null,
+		Genres: value.genres.join(', '),
+		'Time signature':
+			value.time_signature_upper !== null && value.time_signature_lower !== null
+				? `${value.time_signature_upper}/${value.time_signature_lower}`
+				: null,
+		Playable: value.playable ? 'Yes' : 'No'
+	})
+	const before = describe(props.baseline)
+	return Object.entries(describe(props.latest))
+		.filter(([label, value]) => value !== before[label as keyof typeof before])
+		.map(([label, value]) => ({
+			label,
+			value: value === null || value === '' ? 'Not specified' : value
+		}))
+})
+</script>
+
+<template>
+	<div
+		role="alert"
+		class="space-y-3 rounded-md border border-amber-600/30 bg-amber-600/10 p-3 text-sm"
+	>
+		<p class="font-medium">This track changed while you were editing.</p>
+		<template v-if="latest">
+			<p>Your edits have been kept. These are the latest saved values:</p>
+			<dl
+				v-if="changedValues.length"
+				class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1"
+			>
+				<template v-for="change in changedValues" :key="change.label">
+					<dt class="font-medium">{{ change.label }}</dt>
+					<dd class="min-w-0 wrap-anywhere">{{ change.value }}</dd>
+				</template>
+			</dl>
+			<p v-else>
+				Other track data was updated. Your edited fields are unchanged on the
+				server.
+			</p>
+			<p>
+				Keep your edits and review them alongside the latest values before
+				saving again.
+			</p>
+			<Button type="button" variant="outline" @click="$emit('review')">
+				Keep my edits and review
+			</Button>
+		</template>
+		<p v-else>
+			The latest track could not be loaded. Your edits have been kept. Refresh
+			your library and reopen the track to review it.
+		</p>
+	</div>
+</template>

--- a/app/composables/__tests__/useTrackEnrichmentWorkflow.test.ts
+++ b/app/composables/__tests__/useTrackEnrichmentWorkflow.test.ts
@@ -72,6 +72,7 @@ const { useTrackEnrichmentWorkflow } =
 const activeScopes: EffectScope[] = []
 
 function createWorkflow(options?: {
+	captureApplyGuard?: () => () => boolean
 	onApplyAttempt?: (
 		attempt: TrackEnrichmentApplyAttempt
 	) => Promise<void> | void
@@ -83,7 +84,8 @@ function createWorkflow(options?: {
 				typeof useRecordsStore
 			>,
 			tracks: mockTracksStore as unknown as ReturnType<typeof useTracksStore>,
-			onApplyAttempt: options?.onApplyAttempt
+			onApplyAttempt: options?.onApplyAttempt,
+			captureApplyGuard: options?.captureApplyGuard
 		})
 	)
 	if (!workflow) throw new Error('Failed to create enrichment workflow scope')
@@ -1219,6 +1221,10 @@ describe('useTrackEnrichmentWorkflow', () => {
 		await vi.waitFor(() =>
 			expect(mockTracksStore.updateTracksBatch).toHaveBeenCalledOnce()
 		)
+		workflow.startAnotherSource()
+		workflow.loadPreparedReview('replacement.xml', [createRow()])
+		workflow.stagedRowIds.value = new Set(['row-1'])
+		workflow.showApplyDialog.value = true
 		const newApply = workflow.applyStagedRows()
 		await vi.waitFor(() =>
 			expect(mockTracksStore.updateTracksBatch).toHaveBeenCalledTimes(2)
@@ -1247,7 +1253,9 @@ describe('useTrackEnrichmentWorkflow', () => {
 		mockTracksStore.updateTracksBatch.mockReturnValue(batch.promise)
 
 		const applying = workflow.applyStagedRows()
-		await vi.waitFor(() => expect(workflow.isApplying.value).toBe(true))
+		await vi.waitFor(() =>
+			expect(mockTracksStore.updateTracksBatch).toHaveBeenCalledOnce()
+		)
 		const rejected = expect(applying).rejects.toThrow('Connection lost')
 		batch.reject(new Error('Connection lost'))
 		await rejected
@@ -1255,5 +1263,101 @@ describe('useTrackEnrichmentWorkflow', () => {
 		expect(workflow.isApplying.value).toBe(false)
 		expect(workflow.showApplyDialog.value).toBe(false)
 		expect(workflow.lastApplySummary.value).toBeNull()
+	})
+	it('does not dispatch an abandoned apply after asynchronous preparation', async () => {
+		const deferred = createDeferred<TrackBatchUpdate | null>()
+		workflowMocks.buildUpdate.mockReturnValueOnce(deferred.promise)
+		const workflow = createWorkflow()
+		const row = createRow()
+		workflow.loadPreparedReview('original.xml', [row])
+		workflow.stagedRowIds.value = new Set([row.id])
+		const applying = workflow.applyStagedRows()
+		workflow.startAnotherSource()
+		deferred.resolve(toBatchUpdate(row))
+		await applying
+		expect(mockTracksStore.updateTracksBatch).not.toHaveBeenCalled()
+		expect(workflow.isApplying.value).toBe(false)
+	})
+	it.each([
+		'lease loss',
+		'reacquired lease',
+		'page departure',
+		'scope disposal',
+		'workspace replacement'
+	] as const)('does not dispatch preparation after %s', async (reason) => {
+		let isCurrent = true
+		const workflow = createWorkflow({
+			captureApplyGuard: () => () => isCurrent
+		})
+		const row = createRow()
+		workflow.loadPreparedReview('original.xml', [row])
+		workflow.stagedRowIds.value = new Set([row.id])
+		const preparation = createDeferred<TrackBatchUpdate | null>()
+		workflowMocks.buildUpdate.mockReturnValueOnce(preparation.promise)
+		const applying = workflow.applyStagedRows()
+		expect(workflow.isApplying.value).toBe(true)
+		if (reason === 'lease loss' || reason === 'reacquired lease')
+			workflow.setReviewReadOnly(true)
+		if (reason === 'reacquired lease') workflow.setReviewReadOnly(false)
+		if (reason === 'page departure') workflow.cancelPendingApply()
+		if (reason === 'scope disposal') activeScopes.at(-1)!.stop()
+		if (reason === 'workspace replacement') isCurrent = false
+		preparation.resolve(toBatchUpdate(row))
+		await applying
+		expect(mockTracksStore.updateTracksBatch).not.toHaveBeenCalled()
+		expect(workflow.isApplying.value).toBe(false)
+	})
+
+	it('rejects duplicate apply starts during preparation', async () => {
+		const workflow = createWorkflow()
+		const row = createRow()
+		workflow.loadPreparedReview('original.xml', [row])
+		workflow.stagedRowIds.value = new Set([row.id])
+		const preparation = createDeferred<TrackBatchUpdate | null>()
+		workflowMocks.buildUpdate.mockReturnValueOnce(preparation.promise)
+		const applying = workflow.applyStagedRows()
+		await workflow.applyStagedRows()
+		expect(workflowMocks.buildUpdate).toHaveBeenCalledOnce()
+		preparation.resolve(toBatchUpdate(row))
+		await applying
+		expect(mockTracksStore.updateTracksBatch).toHaveBeenCalledOnce()
+	})
+
+	it('clears busy state when preparation itself fails', async () => {
+		const workflow = createWorkflow()
+		workflow.loadPreparedReview('original.xml', [createRow()])
+		workflow.stagedRowIds.value = new Set(['row-1'])
+		workflow.showApplyDialog.value = true
+		workflowMocks.buildUpdate.mockRejectedValueOnce(
+			new Error('Preparation failed')
+		)
+		await expect(workflow.applyStagedRows()).rejects.toThrow(
+			'Preparation failed'
+		)
+		expect(workflow.isApplying.value).toBe(false)
+		expect(workflow.showApplyDialog.value).toBe(false)
+		expect(mockTracksStore.updateTracksBatch).not.toHaveBeenCalled()
+	})
+
+	it('still records an already-dispatched outcome after leaving the page', async () => {
+		const recordAttempt = vi.fn()
+		const workflow = createWorkflow({ onApplyAttempt: recordAttempt })
+		workflow.loadPreparedReview('original.xml', [createRow()])
+		workflow.stagedRowIds.value = new Set(['row-1'])
+		const batch = createDeferred<TrackBatchUpdateOutcome>()
+		mockTracksStore.updateTracksBatch.mockReturnValueOnce(batch.promise)
+		const applying = workflow.applyStagedRows()
+		await vi.waitFor(() =>
+			expect(mockTracksStore.updateTracksBatch).toHaveBeenCalledOnce()
+		)
+		workflow.cancelPendingApply()
+		batch.resolve({
+			cancelled: false,
+			requiresReview: false,
+			results: [updatedBatchResult(createTrack({ bpm: 128 }))]
+		})
+		await applying
+		expect(recordAttempt).toHaveBeenCalledOnce()
+		expect(workflow.isApplying.value).toBe(false)
 	})
 })

--- a/app/composables/useTrackEnrichmentWorkflow.ts
+++ b/app/composables/useTrackEnrichmentWorkflow.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, Ref } from 'vue'
-import { nextTick, shallowRef } from 'vue'
+import { nextTick, onScopeDispose, shallowRef, watch } from 'vue'
 import { toast } from 'vue-sonner'
 import type { LocalAudioReviewSelection } from '~/types/localAudio'
 import {
@@ -135,10 +135,12 @@ export type TrackEnrichmentWorkflow = {
 	clearStagedRows: () => void
 	openApplyReview: () => void
 	applyStagedRows: () => Promise<void>
+	cancelPendingApply: () => void
 	returnToReview: () => void
 }
 
 export type TrackEnrichmentWorkflowDependencies = {
+	captureApplyGuard?: () => () => boolean
 	records: ReturnType<typeof useRecordsStore>
 	tracks: ReturnType<typeof useTracksStore>
 	onApplyAttempt?: (
@@ -207,6 +209,18 @@ export function useTrackEnrichmentWorkflow(
 	const requiresSourceReconnect = ref(false)
 	const isReviewReadOnly = ref(false)
 	const retryRekordboxFile = shallowRef<File | null>(null)
+	let applyPermissionGeneration = 0
+	function cancelPendingApply() {
+		applyPermissionGeneration++
+	}
+	watch(
+		isReviewReadOnly,
+		(readOnly) => {
+			if (readOnly) cancelPendingApply()
+		},
+		{ flush: 'sync' }
+	)
+	onScopeDispose(cancelPendingApply)
 	let reviewOperationGeneration = 0
 	let applyOperationGeneration = 0
 	let activeRekordboxParse: RekordboxXmlWorkerParseHandle | null = null
@@ -687,6 +701,7 @@ export function useTrackEnrichmentWorkflow(
 	}
 
 	async function applyStagedRows() {
+		if (isApplying.value) return
 		if (isReviewReadOnly.value) {
 			toast.warning('Take over this draft before changing or applying it.')
 			return
@@ -698,7 +713,16 @@ export function useTrackEnrichmentWorkflow(
 			isApplying.value = false
 			showApplyDialog.value = false
 		}
-		const rowsToApply = stagedRows.value
+		const permissionGeneration = applyPermissionGeneration
+		const isCurrentContext = dependencies?.captureApplyGuard?.() ?? (() => true)
+		const mayDispatch = () =>
+			ownsOperation() &&
+			isCurrentContext() &&
+			!isReviewReadOnly.value &&
+			permissionGeneration === applyPermissionGeneration
+		const rowsToApply = [...stagedRows.value]
+		const fileLabel = selectedFileName.value ?? sourceLabel.value
+		isApplying.value = true
 		const importedAt = new Date().toISOString()
 		const preparedUpdates: {
 			row: TrackEnrichmentRow
@@ -708,47 +732,49 @@ export function useTrackEnrichmentWorkflow(
 			>
 		}[] = []
 
-		for (const row of rowsToApply) {
-			const intentKind = getTrackEnrichmentIntentKind(row)
-			const update = await buildTrackEnrichmentUpdate(
-				row,
-				selectedFileName.value ?? sourceLabel.value,
-				importedAt,
-				intentKind
-			)
-			if (update) {
-				preparedUpdates.push({
-					row,
-					intentKind,
-					update
-				})
-			}
-		}
-
-		if (preparedUpdates.length === 0) {
-			toast.warning('No staged matches can be applied.')
-			showApplyDialog.value = false
-			return
-		}
-
-		isApplying.value = true
-		applyCompleted.value = 0
-		applyTotal.value = preparedUpdates.length
-		rows.value = rows.value.map((row) =>
-			stagedRowIds.value.has(row.id) ? { ...row, error: null } : row
-		)
-
 		try {
+			if (!mayDispatch()) return
+			for (const row of rowsToApply) {
+				const intentKind = getTrackEnrichmentIntentKind(row)
+				const update = await buildTrackEnrichmentUpdate(
+					row,
+					fileLabel,
+					importedAt,
+					intentKind
+				)
+				if (!mayDispatch()) return
+				if (update) {
+					preparedUpdates.push({
+						row,
+						intentKind,
+						update
+					})
+				}
+			}
+
+			if (!mayDispatch()) return
+			if (preparedUpdates.length === 0) {
+				toast.warning('No staged matches can be applied.')
+				showApplyDialog.value = false
+				return
+			}
+
+			applyCompleted.value = 0
+			applyTotal.value = preparedUpdates.length
+			rows.value = rows.value.map((row) =>
+				stagedRowIds.value.has(row.id) ? { ...row, error: null } : row
+			)
+
 			const outcome = await tracks.updateTracksBatch(
 				preparedUpdates.map((entry) => entry.update),
 				{
 					onProgress: (completed) => {
-						if (!ownsOperation()) return
+						if (!ownsOperation() || !isCurrentContext()) return
 						applyCompleted.value = completed
 					}
 				}
 			)
-			if (!ownsOperation()) return
+			if (!ownsOperation() || !isCurrentContext()) return
 			const confirmedOutcome = outcome.cancelled
 				? {
 						...outcome,
@@ -771,7 +797,7 @@ export function useTrackEnrichmentWorkflow(
 				outcome: confirmedOutcome,
 				attemptedAt: importedAt
 			})
-			if (!ownsOperation()) return
+			if (!ownsOperation() || !isCurrentContext()) return
 			const results = confirmedOutcome.results
 			const resultByTrackId = new Map(
 				results.map((result) => [result.id, result])
@@ -855,11 +881,9 @@ export function useTrackEnrichmentWorkflow(
 			} else {
 				toast.success(`Applied ${succeeded} of ${results.length}.`)
 			}
-		} catch (error) {
+		} finally {
 			finishOwnedOperation()
-			throw error
 		}
-		finishOwnedOperation()
 	}
 
 	function returnToReview() {
@@ -934,6 +958,7 @@ export function useTrackEnrichmentWorkflow(
 		clearStagedRows,
 		openApplyReview,
 		applyStagedRows,
+		cancelPendingApply,
 		returnToReview
 	}
 }

--- a/app/repositories/library/browser/browserLibraryRepository.ts
+++ b/app/repositories/library/browser/browserLibraryRepository.ts
@@ -885,7 +885,7 @@ function createTracksRepository(
 			)
 		},
 
-		update(context, { id, updates }) {
+		update(context, { id, updates, expectedUpdatedAt }) {
 			return state.command(
 				context,
 				{
@@ -901,6 +901,14 @@ function createTracksRepository(
 					const existing = withoutWorkspaceId(
 						decodeBrowserTrackRow(stored, workspaceId)
 					)
+					if (
+						expectedUpdatedAt !== undefined &&
+						existing.updated_at !== expectedUpdatedAt
+					) {
+						throw new BrowserRepositoryDomainConflictError(
+							'precondition-failed'
+						)
+					}
 					const candidate = domainValue(() =>
 						decodeLibraryTrack({
 							...existing,

--- a/app/repositories/library/cloud/cloudTracksRepository.ts
+++ b/app/repositories/library/cloud/cloudTracksRepository.ts
@@ -210,19 +210,31 @@ export function createCloudTracksRepository(
 			}
 		},
 
-		async update(context, { id, updates }) {
+		async update(context, { id, updates, expectedUpdatedAt }) {
 			const captured = await state.capture(context)
 			if (!state.isLease(captured)) return captured
 			try {
-				const { data, error } = await dependencies.supabase
+				let query = dependencies.supabase
 					.from('tracks')
 					.update(toTrackUpdatePayload(updates))
 					.eq('id', id)
 					.eq('user_id', captured.userId)
-					.select()
-					.single()
+				if (expectedUpdatedAt !== undefined) {
+					query =
+						expectedUpdatedAt === null
+							? query.is('updated_at', null)
+							: query.eq('updated_at', expectedUpdatedAt)
+				}
+				const selected = query.select()
+				const { data, error } =
+					expectedUpdatedAt === undefined
+						? await selected.single()
+						: await selected.maybeSingle()
 				if (!(await state.isCurrent(captured))) return { status: 'stale' }
 				if (error) return state.transportFailure(error)
+				if (!data && expectedUpdatedAt !== undefined) {
+					return { status: 'conflict', reason: 'precondition-failed' }
+				}
 				if (!data || data.id !== id || data.user_id !== captured.userId) {
 					return { status: 'conflict', reason: 'integrity' }
 				}

--- a/app/repositories/library/contracts.ts
+++ b/app/repositories/library/contracts.ts
@@ -127,7 +127,11 @@ export interface TracksRepository {
 	): RepositoryCommand<LibraryTrack>
 	update(
 		context: WorkspaceOperationContext,
-		input: { id: string; updates: LibraryTrackUpdateInput }
+		input: {
+			id: string
+			updates: LibraryTrackUpdateInput
+			expectedUpdatedAt?: string | null
+		}
 	): RepositoryCommand<LibraryTrack>
 	updateBatch(
 		context: WorkspaceOperationContext,

--- a/app/stores/__tests__/tracksStore.crud.test.ts
+++ b/app/stores/__tests__/tracksStore.crud.test.ts
@@ -240,6 +240,66 @@ describe('tracksStore CRUD', () => {
 			expect(result).toBeNull()
 		})
 
+		it.each([null, '2026-09-07T10:00:00.000001Z'])(
+			'passes the editor version %s to an atomic conditional update',
+			async (expectedUpdatedAt) => {
+				const store = createTracksStore()
+				store.tracks = [createMockTrack({ id: 'track-1' })]
+				mockQueryBuilder.maybeSingle.mockResolvedValue({
+					data: createMockOwnedTrack({ id: 'track-1', title: 'My title' }),
+					error: null
+				})
+				const result = await store.updateTrack(
+					'track-1',
+					{ title: 'My title' },
+					{ expectedUpdatedAt }
+				)
+				expect(result?.title).toBe('My title')
+				if (expectedUpdatedAt === null)
+					expect(mockQueryBuilder.is).toHaveBeenCalledWith('updated_at', null)
+				else
+					expect(mockQueryBuilder.eq).toHaveBeenCalledWith(
+						'updated_at',
+						expectedUpdatedAt
+					)
+				expect(mockQueryBuilder.update).toHaveBeenCalledWith({
+					title: 'My title'
+				})
+				expect(mockQueryBuilder.single).not.toHaveBeenCalled()
+			}
+		)
+
+		it('refreshes the saved values and reports a version conflict without a success toast', async () => {
+			const store = createTracksStore()
+			store.tracks = [
+				createMockTrack({ id: 'track-1', title: 'Old title', bpm: 128 })
+			]
+			const latest = createMockOwnedTrack({
+				id: 'track-1',
+				title: 'Other title',
+				bpm: 140
+			})
+			mockQueryBuilder.maybeSingle.mockResolvedValue({
+				data: null,
+				error: null
+			})
+			mockQueryBuilder.limit.mockResolvedValue({ data: [latest], error: null })
+			const onConflict = vi.fn()
+			const result = await store.updateTrack(
+				'track-1',
+				{ title: 'My title' },
+				{ expectedUpdatedAt: '2026-09-07T10:00:00Z', onConflict }
+			)
+			expect(result).toBeNull()
+			expect(store.tracks[0]).toMatchObject({ title: 'Other title', bpm: 140 })
+			expect(onConflict).toHaveBeenCalledWith(
+				expect.objectContaining({ title: 'Other title', bpm: 140 })
+			)
+			expect(onConflict.mock.calls[0]![0]).not.toHaveProperty('user_id')
+			expect(mockToast.success).not.toHaveBeenCalled()
+			expect(store.isUpdatingTrack).toBe(false)
+		})
+
 		it('performs optimistic update', async () => {
 			const store = createTracksStore()
 			store.tracks = [createMockTrack({ id: 'track-1', title: 'Original' })]

--- a/app/stores/__tests__/tracksStoreTestHarness.ts
+++ b/app/stores/__tests__/tracksStoreTestHarness.ts
@@ -44,7 +44,8 @@ function createMockQueryBuilder() {
 		order: vi.fn().mockReturnThis(),
 		lt: vi.fn().mockReturnThis(),
 		limit: vi.fn().mockResolvedValue({ data: [], error: null }),
-		single: vi.fn().mockResolvedValue({ data: null, error: null })
+		single: vi.fn().mockResolvedValue({ data: null, error: null }),
+		maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
 	}
 }
 

--- a/app/stores/__tests__/userStore.accountSecurity.test.ts
+++ b/app/stores/__tests__/userStore.accountSecurity.test.ts
@@ -1,6 +1,7 @@
 import { nextTick } from 'vue'
 import { toast } from 'vue-sonner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ACCOUNT_DELETION_QUEUED_RESPONSE } from '../../../shared/types/accountDeletion'
 import { useUserStore as createPiniaUserStore } from '../userStore'
 import {
 	createDeferred,
@@ -107,7 +108,7 @@ describe('userStore account security', () => {
 
 			expect(result).toEqual({
 				status: 'deleted',
-				coverCleanupComplete: true
+				cleanupState: 'complete'
 			})
 			expect(
 				mockAccountBoundSupabaseClient.functions.invoke
@@ -127,6 +128,71 @@ describe('userStore account security', () => {
 			expect(mockRouter.replace).toHaveBeenCalledWith('/login')
 			expect(mockToast.success).toHaveBeenCalledWith(
 				'Your account and its data have been deleted.'
+			)
+		})
+
+		it.each([
+			ACCOUNT_DELETION_QUEUED_RESPONSE,
+			{
+				success: true,
+				cover_cleanup_complete: false,
+				cleanup_queue_complete: false,
+				cleanup_queued: true
+			}
+		])(
+			'acknowledges the producer queued response without a cleanup warning: %#',
+			async (data) => {
+				const store = useUserStore()
+				mockAccountBoundSupabaseClient.functions.invoke.mockResolvedValue({
+					data,
+					error: null
+				})
+				const result = await store.deleteAccount('test@example.com')
+				expect(result).toEqual({ status: 'deleted', cleanupState: 'queued' })
+				expect(mockToast.warning).not.toHaveBeenCalled()
+				expect(mockToast.success).toHaveBeenCalledWith(
+					'Your account has been deleted. Remaining cover images will be removed in the background.'
+				)
+				expect(mockRouter.replace).toHaveBeenCalledWith('/login')
+			}
+		)
+
+		it('keeps a local sign-out failure separate from successful queued cleanup', async () => {
+			const store = useUserStore()
+			mockAccountBoundSupabaseClient.functions.invoke.mockResolvedValue({
+				data: ACCOUNT_DELETION_QUEUED_RESPONSE,
+				error: null
+			})
+			mockSupabaseClient.auth.signOut.mockResolvedValue({
+				error: new Error('Local sign out failed')
+			})
+			expect(await store.deleteAccount('test@example.com')).toEqual({
+				status: 'deleted',
+				cleanupState: 'queued'
+			})
+			expect(mockToast.warning).toHaveBeenCalledOnce()
+			expect(mockToast.warning).toHaveBeenCalledWith(
+				'Your account was deleted. Reload the page if you still appear signed in.',
+				{ duration: 30000 }
+			)
+		})
+
+		it('reports an explicitly failed cleanup without claiming all data was removed', async () => {
+			const store = useUserStore()
+			mockAccountBoundSupabaseClient.functions.invoke.mockResolvedValue({
+				data: { success: true, cleanup_state: 'failed' },
+				error: null
+			})
+			expect(await store.deleteAccount('test@example.com')).toEqual({
+				status: 'deleted',
+				cleanupState: 'failed'
+			})
+			expect(mockToast.warning).toHaveBeenCalledWith(
+				'Your account was deleted, but cover cleanup needs attention. Contact the project owner for help.',
+				{ duration: 30000 }
+			)
+			expect(mockToast.success).toHaveBeenCalledWith(
+				'Your account has been deleted.'
 			)
 		})
 
@@ -165,7 +231,7 @@ describe('userStore account security', () => {
 
 			expect(result).toEqual({
 				status: 'deleted',
-				coverCleanupComplete: true
+				cleanupState: 'complete'
 			})
 			expect(mockSupaUser.value).toBeNull()
 			expect(mockToast.warning).toHaveBeenCalledWith(
@@ -185,10 +251,10 @@ describe('userStore account security', () => {
 
 			expect(result).toEqual({
 				status: 'deleted',
-				coverCleanupComplete: false
+				cleanupState: 'unknown'
 			})
 			expect(mockToast.warning).toHaveBeenCalledWith(
-				'Your account was deleted, but server-side cover cleanup did not finish. Contact the project owner if a cover remains accessible.',
+				'Your account was deleted, but cover cleanup could not be confirmed. Contact the project owner if a cover remains accessible.',
 				{ duration: 30000 }
 			)
 		})
@@ -208,10 +274,10 @@ describe('userStore account security', () => {
 
 			expect(result).toEqual({
 				status: 'deleted',
-				coverCleanupComplete: false
+				cleanupState: 'unknown'
 			})
 			expect(mockToast.warning).toHaveBeenCalledWith(
-				'Your account was deleted, but server-side cover cleanup did not finish. Contact the project owner if a cover remains accessible.',
+				'Your account was deleted, but cover cleanup could not be confirmed. Contact the project owner if a cover remains accessible.',
 				{ duration: 30000 }
 			)
 		})
@@ -311,7 +377,7 @@ describe('userStore account security', () => {
 			deletion.resolve({ data: { success: true }, error: null })
 			await expect(firstResult).resolves.toEqual({
 				status: 'deleted',
-				coverCleanupComplete: true
+				cleanupState: 'complete'
 			})
 		})
 
@@ -388,7 +454,7 @@ describe('userStore account security', () => {
 			firstDeletion.resolve({ data: { success: true }, error: null })
 			await expect(accountAResult).resolves.toEqual({
 				status: 'deleted',
-				coverCleanupComplete: true
+				cleanupState: 'complete'
 			})
 			expect(store.isDeletingAccount).toBe(true)
 			expect(store.profile).toEqual(replacementProfile)
@@ -399,7 +465,7 @@ describe('userStore account security', () => {
 			secondDeletion.resolve({ data: { success: true }, error: null })
 			await expect(accountBResult).resolves.toEqual({
 				status: 'deleted',
-				coverCleanupComplete: true
+				cleanupState: 'complete'
 			})
 			expect(store.isDeletingAccount).toBe(false)
 			expect(mockSupabaseClient.auth.signOut).toHaveBeenCalledOnce()
@@ -429,7 +495,7 @@ describe('userStore account security', () => {
 			deletion.resolve({ data: { success: true }, error: null })
 			await expect(accountAResult).resolves.toEqual({
 				status: 'deleted',
-				coverCleanupComplete: true
+				cleanupState: 'complete'
 			})
 			expect(mockSupabaseClient.auth.signOut).not.toHaveBeenCalled()
 			expect(mockRouter.replace).not.toHaveBeenCalled()
@@ -502,7 +568,7 @@ describe('userStore account security', () => {
 
 			await expect(accountAResult).resolves.toEqual({
 				status: 'deleted',
-				coverCleanupComplete: true
+				cleanupState: 'complete'
 			})
 			expect(store.profile).toEqual(replacementProfile)
 			expect(mockRouter.replace).not.toHaveBeenCalled()

--- a/app/stores/tracksStore.ts
+++ b/app/stores/tracksStore.ts
@@ -38,6 +38,12 @@ type TrackMutationProvenance = FetchContext & { revision: number } & (
 		{ kind: 'create' | 'update'; row: LibraryTrack } | { kind: 'delete' }
 	)
 
+export type TrackUpdateOptions = {
+	silent?: boolean
+	expectedUpdatedAt?: string | null
+	onConflict?: (current: LibraryTrack | null) => void
+}
+
 type ApplyTrackUpdateResult = {
 	track: LibraryTrack | null
 	error: string | null
@@ -440,7 +446,8 @@ export const useTracksStore = defineStore('tracks', () => {
 		options?: {
 			suppressSuccessToast?: boolean
 			suppressErrorToast?: boolean
-			preconditions?: TrackBatchUpdate['preconditions']
+			expectedUpdatedAt?: string | null
+			onConflict?: TrackUpdateOptions['onConflict']
 		}
 	): Promise<ApplyTrackUpdateResult> {
 		if (runtime.capture().descriptor.readOnly)
@@ -480,6 +487,9 @@ export const useTracksStore = defineStore('tracks', () => {
 				}
 
 				const originalTrack = tracks.value[trackIndex]!
+				if (Object.keys(updates).length === 0) {
+					return { track: originalTrack, error: null, issues: [], stale: false }
+				}
 				const optimisticTrack = {
 					...originalTrack,
 					...updates
@@ -493,11 +503,51 @@ export const useTracksStore = defineStore('tracks', () => {
 					if (!repositories) return staleResult
 					const outcome = await repositories.tracks.update(context, {
 						id,
-						updates
+						updates,
+						expectedUpdatedAt: options?.expectedUpdatedAt
 					})
 
 					if (!isCurrentAccountContext(context) || outcome.status === 'stale') {
 						return { track: null, error: null, issues: [], stale: true }
+					}
+					if (
+						outcome.status === 'conflict' &&
+						outcome.reason === 'precondition-failed'
+					) {
+						if (trackOperationRevisions.get(id) !== operationRevision)
+							return staleResult
+						const currentIndex = tracks.value.findIndex(
+							(track) => track.id === id
+						)
+						if (
+							currentIndex !== -1 &&
+							toRaw(tracks.value[currentIndex]) === optimisticTrack
+						) {
+							tracks.value[currentIndex] = originalTrack
+						}
+						const refreshed = await fetchAllTracks({ fresh: true })
+						if (
+							!isCurrentAccountContext(context) ||
+							trackOperationRevisions.get(id) !== operationRevision
+						)
+							return staleResult
+						if (options?.onConflict) {
+							options.onConflict(
+								refreshed
+									? (tracks.value.find((track) => track.id === id) ?? null)
+									: null
+							)
+						} else if (!options?.suppressErrorToast) {
+							toast.warning(
+								'This track changed after you started editing. Review its latest values before saving again.'
+							)
+						}
+						return {
+							track: null,
+							error: 'Track changed after editing began.',
+							issues: [],
+							stale: false
+						}
 					}
 					if (outcome.status !== 'success') {
 						throw outcome.status === 'unavailable'
@@ -568,7 +618,7 @@ export const useTracksStore = defineStore('tracks', () => {
 	async function updateTrack(
 		id: string,
 		updates: TrackUpdateInput,
-		options?: { silent?: boolean }
+		options?: TrackUpdateOptions
 	): Promise<LibraryTrack | null> {
 		const context = await resolveMutationContext(accountGeneration)
 		if (!context) return null
@@ -577,7 +627,9 @@ export const useTracksStore = defineStore('tracks', () => {
 		try {
 			const result = await applyTrackUpdate(context, id, updates, {
 				suppressSuccessToast: options?.silent,
-				suppressErrorToast: false
+				suppressErrorToast: false,
+				expectedUpdatedAt: options?.expectedUpdatedAt,
+				onConflict: options?.onConflict
 			})
 			if (result.stale || !isCurrentAccountContext(context)) return null
 			reportDecodeIssues(result.issues, (message) => toast.warning(message))

--- a/app/stores/userStore.ts
+++ b/app/stores/userStore.ts
@@ -10,6 +10,10 @@ import {
 	isDemoWorkbenchPinia
 } from '~/utils/workbenchPinia'
 import {
+	type AccountCleanupState,
+	readAccountCleanupState
+} from '../../shared/types/accountDeletion'
+import {
 	buildCheckInboxPath,
 	buildLoginRedirectPath,
 	buildUpdatePasswordPath,
@@ -35,7 +39,7 @@ export type IdentityProfile = Pick<
 >
 
 export type DeleteAccountResult =
-	| { status: 'deleted'; coverCleanupComplete: boolean }
+	| { status: 'deleted'; cleanupState: AccountCleanupState }
 	| { status: 'recent-auth-required' }
 	| { status: 'failed' }
 
@@ -464,14 +468,10 @@ export const useUserStore = defineStore('user', () => {
 			) {
 				throw new Error('Your account could not be deleted. Please try again.')
 			}
-			const coverCleanupComplete =
-				(!('cover_cleanup_complete' in data) ||
-					data.cover_cleanup_complete !== false) &&
-				(!('cleanup_queue_complete' in data) ||
-					data.cleanup_queue_complete !== false)
+			const cleanupState = readAccountCleanupState(data)
 			const deletionResult: DeleteAccountResult = {
 				status: 'deleted',
-				coverCleanupComplete
+				cleanupState
 			}
 			if (!isCurrentWork(work)) return deletionResult
 
@@ -491,9 +491,11 @@ export const useUserStore = defineStore('user', () => {
 			if (signOutError) {
 				console.error('Deleted account, but local auth cleanup failed')
 			}
-			if (!coverCleanupComplete) {
+			if (cleanupState === 'failed' || cleanupState === 'unknown') {
 				toast.warning(
-					'Your account was deleted, but server-side cover cleanup did not finish. Contact the project owner if a cover remains accessible.',
+					cleanupState === 'failed'
+						? 'Your account was deleted, but cover cleanup needs attention. Contact the project owner for help.'
+						: 'Your account was deleted, but cover cleanup could not be confirmed. Contact the project owner if a cover remains accessible.',
 					{ duration: 30000 }
 				)
 			}
@@ -517,7 +519,13 @@ export const useUserStore = defineStore('user', () => {
 					{ duration: 30000 }
 				)
 			} else {
-				toast.success('Your account and its data have been deleted.')
+				toast.success(
+					cleanupState === 'queued'
+						? 'Your account has been deleted. Remaining cover images will be removed in the background.'
+						: cleanupState === 'complete'
+							? 'Your account and its data have been deleted.'
+							: 'Your account has been deleted.'
+				)
 			}
 			return deletionResult
 		} catch (error) {

--- a/app/utils/authRoutes.test.ts
+++ b/app/utils/authRoutes.test.ts
@@ -13,6 +13,10 @@ import {
 describe('auth route policy', () => {
 	it.each([
 		'/login',
+		'/login/',
+		'/LOGIN/',
+		'/Privacy/',
+		'/TERMS/',
 		'/signup',
 		'/reset-password',
 		'/update-password',
@@ -34,7 +38,6 @@ describe('auth route policy', () => {
 		'/auth/discogs/capture-verifier',
 		'/auth/future-callback',
 		'/auth/confirm/extra',
-		'/login/',
 		'/signup-extra',
 		'/demo-private',
 		'/demonstration'
@@ -42,7 +45,7 @@ describe('auth route policy', () => {
 		expect(isPublicRoute(path)).toBe(false)
 	})
 
-	it.each(['/login', '/signup', '/reset-password'])(
+	it.each(['/login', '/signup', '/reset-password', '/LOGIN/', '/Signup/'])(
 		'classifies %s as signed-out only',
 		(path) => {
 			expect(isSignedOutOnlyRoute(path)).toBe(true)
@@ -69,6 +72,7 @@ describe('auth return paths', () => {
 		'/privacy',
 		'/terms',
 		'/records?crate=house&sort=year#release-1',
+		'/TRACKS/?genre=House#Results',
 		'/demo/records?crate=house'
 	])('preserves safe internal path %s', (path) => {
 		expect(sanitizeAuthReturnPath(path)).toBe(path)
@@ -97,6 +101,9 @@ describe('auth return paths', () => {
 		'/login',
 		'/login?redirect=/records',
 		'/login#retry',
+		'/LOGIN/?redirect=/tracks',
+		'/Auth/Confirm/#callback',
+		'/%6cogin/',
 		'/signup?redirect=/records',
 		'/reset-password#form',
 		'/update-password?redirect=/records',

--- a/app/utils/authRoutes.ts
+++ b/app/utils/authRoutes.ts
@@ -1,28 +1,11 @@
-const PUBLIC_AUTH_ROUTES = new Set([
-	'/login',
-	'/signup',
-	'/reset-password',
-	'/update-password',
-	'/auth/check-inbox',
-	'/auth/confirm',
-	'/auth/finalising'
-])
-
-const PUBLIC_LEGAL_ROUTES = new Set(['/privacy', '/terms'])
-
-const SIGNED_OUT_ONLY_ROUTES = new Set(['/login', '/signup', '/reset-password'])
+import { getRoutePolicy } from './routePolicy'
 
 export function isPublicRoute(path: string): boolean {
-	return (
-		PUBLIC_AUTH_ROUTES.has(path) ||
-		PUBLIC_LEGAL_ROUTES.has(path) ||
-		path === '/demo' ||
-		path.startsWith('/demo/')
-	)
+	return getRoutePolicy(path).access !== 'authenticated'
 }
 
 export function isSignedOutOnlyRoute(path: string): boolean {
-	return SIGNED_OUT_ONLY_ROUTES.has(path)
+	return getRoutePolicy(path).access === 'signed-out'
 }
 
 function hasUnsafePathCharacters(value: string): boolean {
@@ -57,8 +40,8 @@ export function sanitizeAuthReturnPath(value: unknown): string {
 	if (
 		decodedValue.startsWith('//') ||
 		hasUnsafePathCharacters(decodedValue) ||
-		PUBLIC_AUTH_ROUTES.has(pathWithoutQueryOrHash(value)) ||
-		PUBLIC_AUTH_ROUTES.has(pathWithoutQueryOrHash(decodedValue))
+		getRoutePolicy(pathWithoutQueryOrHash(value)).authPage ||
+		getRoutePolicy(pathWithoutQueryOrHash(decodedValue)).authPage
 	)
 		return '/'
 

--- a/app/utils/routePolicy.ts
+++ b/app/utils/routePolicy.ts
@@ -1,0 +1,42 @@
+type RoutePolicy = Readonly<{
+	access: 'public' | 'signed-out' | 'authenticated'
+	authPage: boolean
+	cloudWorkbench: boolean
+}>
+
+const PUBLIC: RoutePolicy = {
+	access: 'public',
+	authPage: false,
+	cloudWorkbench: false
+}
+const AUTH: RoutePolicy = { ...PUBLIC, authPage: true }
+const SIGNED_OUT: RoutePolicy = { ...AUTH, access: 'signed-out' }
+const PROTECTED: RoutePolicy = { ...PUBLIC, access: 'authenticated' }
+const WORKBENCH: RoutePolicy = { ...PROTECTED, cloudWorkbench: true }
+
+const ROUTES: Readonly<Record<string, RoutePolicy>> = {
+	'/': WORKBENCH,
+	'/crates': WORKBENCH,
+	'/enrichment': WORKBENCH,
+	'/records': WORKBENCH,
+	'/settings': WORKBENCH,
+	'/tracks': WORKBENCH,
+	'/login': SIGNED_OUT,
+	'/signup': SIGNED_OUT,
+	'/reset-password': SIGNED_OUT,
+	'/update-password': AUTH,
+	'/auth/check-inbox': AUTH,
+	'/auth/confirm': AUTH,
+	'/auth/finalising': AUTH,
+	'/privacy': PUBLIC,
+	'/terms': PUBLIC
+}
+
+/** Match Vue Router's static-route case and optional trailing slash policy.
+ * Only classify the pathname; keep the original URL and its query/hash intact.
+ */
+export function getRoutePolicy(pathname: string): RoutePolicy {
+	const path = pathname.replace(/\/$/, '').toLowerCase() || '/'
+	if (path === '/demo' || path.startsWith('/demo/')) return PUBLIC
+	return Object.hasOwn(ROUTES, path) ? ROUTES[path]! : PROTECTED
+}

--- a/app/utils/trackEditor.test.ts
+++ b/app/utils/trackEditor.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
 	type TrackEditorFormValues,
+	buildTrackEditorPatch,
 	buildTrackEditorPayload,
+	createTrackEditorBaseline,
 	createTrackEditorInitialValues,
 	hasTrackEditorChanges,
 	trackEditorSchema,
@@ -133,6 +135,51 @@ describe('buildTrackEditorPayload', () => {
 		expect(payload.artists).toEqual([validArtist])
 		expect(payload.extraartists).toEqual([validArtist])
 	})
+})
+
+describe('track editor patches', () => {
+	it('does not mutate its baseline when the source artist metadata changes', () => {
+		const track = createTrack()
+		const baseline = createTrackEditorBaseline(track)
+		track.artists[0]!.name = 'Changed artist'
+		track.extraartists[0]!.role = 'Remix'
+		track.genres.push('Disco')
+		const edited = buildTrackEditorPayload(
+			trackToEditorValues(track),
+			track.artists,
+			track.extraartists
+		)
+		expect(buildTrackEditorPatch(baseline.payload, edited)).toEqual({
+			artists: track.artists,
+			extraartists: track.extraartists,
+			genres: ['House', 'Disco']
+		})
+	})
+
+	it.each([
+		[{ key: 9 }, { key: 9, mode: 0 }],
+		[{ mode: 1 }, { key: 0, mode: 1 }],
+		[
+			{ key: null, mode: null },
+			{ key: null, mode: null }
+		],
+		[
+			{ time_signature_upper: 3 },
+			{ time_signature_upper: 3, time_signature_lower: 4 }
+		],
+		[
+			{ time_signature_lower: 8 },
+			{ time_signature_upper: 4, time_signature_lower: 8 }
+		]
+	])(
+		'keeps coupled musical values together in a partial edit %j',
+		(edit, expected) => {
+			const baseline = createTrackEditorBaseline(createTrack()).payload
+			expect(buildTrackEditorPatch(baseline, { ...baseline, ...edit })).toEqual(
+				expected
+			)
+		}
+	)
 })
 
 describe('hasTrackEditorChanges', () => {

--- a/app/utils/trackEditor.ts
+++ b/app/utils/trackEditor.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import type { DiscogsArtistDb } from '../../shared/types/discogs'
 import { isDiscogsArtistDb } from '../../shared/types/discogs'
-import type { Track } from '../../shared/types/supabase'
+import type { LibraryTrack } from '../../shared/types/library'
 import { mmssToMs, msToMMSS, parseBPM } from './formatting'
 import { createKeyComposite, parseKeyComposite } from './keyFunctions'
 import {
@@ -31,7 +31,7 @@ export const trackEditorSchema = z.object({
 export type TrackEditorFormValues = z.infer<typeof trackEditorSchema>
 
 export type TrackEditorPayload = Pick<
-	Track,
+	LibraryTrack,
 	| 'title'
 	| 'artists'
 	| 'extraartists'
@@ -62,7 +62,9 @@ export function createTrackEditorInitialValues(): TrackEditorFormValues {
 	}
 }
 
-export function trackToEditorValues(track: Track): TrackEditorFormValues {
+export function trackToEditorValues(
+	track: TrackEditorPayload
+): TrackEditorFormValues {
 	return {
 		title: track.title || '',
 		position: track.position || '',
@@ -78,7 +80,7 @@ export function trackToEditorValues(track: Track): TrackEditorFormValues {
 }
 
 function filterArtists(artists: readonly unknown[]): DiscogsArtistDb[] {
-	return artists.filter(isDiscogsArtistDb)
+	return artists.filter(isDiscogsArtistDb).map((artist) => ({ ...artist }))
 }
 
 export function buildTrackEditorPayload(
@@ -127,7 +129,7 @@ function completeTrackEditorValues(
 }
 
 export function hasTrackEditorChanges(
-	track: Track,
+	track: TrackEditorPayload,
 	values: Partial<TrackEditorFormValues>,
 	artists: readonly unknown[],
 	extraartists: readonly unknown[]
@@ -144,4 +146,48 @@ export function hasTrackEditorChanges(
 	)
 
 	return JSON.stringify(current) !== JSON.stringify(edited)
+}
+
+export type TrackEditorBaseline = {
+	id: string
+	updatedAt: string | null
+	payload: TrackEditorPayload
+}
+
+export function createTrackEditorBaseline(
+	track: LibraryTrack
+): TrackEditorBaseline {
+	return {
+		id: track.id,
+		updatedAt: track.updated_at,
+		payload: buildTrackEditorPayload(
+			trackToEditorValues(track),
+			track.artists,
+			track.extraartists
+		)
+	}
+}
+
+/** Compare to the values the editor actually displayed, not its live store row. */
+export function buildTrackEditorPatch(
+	baseline: TrackEditorPayload,
+	edited: TrackEditorPayload
+): Partial<TrackEditorPayload> {
+	const patch: Partial<TrackEditorPayload> = Object.fromEntries(
+		Object.entries(edited).filter(
+			([field, value]) =>
+				JSON.stringify(value) !==
+				JSON.stringify(baseline[field as keyof TrackEditorPayload])
+		)
+	)
+	// Tonality and time signature are each one logical editor field.
+	if ('key' in patch || 'mode' in patch) {
+		patch.key = edited.key
+		patch.mode = edited.mode
+	}
+	if ('time_signature_upper' in patch || 'time_signature_lower' in patch) {
+		patch.time_signature_upper = edited.time_signature_upper
+		patch.time_signature_lower = edited.time_signature_lower
+	}
+	return patch
 }

--- a/app/utils/workbenchRuntimeAvailability.test.ts
+++ b/app/utils/workbenchRuntimeAvailability.test.ts
@@ -2,18 +2,28 @@ import { describe, expect, it } from 'vitest'
 import { requiresCloudWorkbenchRuntime } from './workbenchRuntimeAvailability'
 
 describe('workbench runtime availability', () => {
-	it.each(['/', '/records', '/tracks', '/crates', '/settings', '/enrichment'])(
-		'loads the Cloud runtime for %s',
-		(path) => {
-			expect(requiresCloudWorkbenchRuntime(path)).toBe(true)
-		}
-	)
+	it.each([
+		'/',
+		'/records',
+		'/tracks',
+		'/crates',
+		'/settings',
+		'/enrichment',
+		'/tracks/',
+		'/TRACKS/',
+		'/Records/'
+	])('loads the Cloud runtime for %s', (path) => {
+		expect(requiresCloudWorkbenchRuntime(path)).toBe(true)
+	})
 
 	it.each([
 		'/demo',
 		'/demo/records',
 		'/login',
 		'/privacy',
+		'/PRIVACY/',
+		'/Demo/records/',
+		'/login/',
 		'/local',
 		'/local/records'
 	])('does not load the Cloud runtime for %s', (path) => {

--- a/app/utils/workbenchRuntimeAvailability.ts
+++ b/app/utils/workbenchRuntimeAvailability.ts
@@ -1,13 +1,6 @@
-const CLOUD_WORKBENCH_ROUTES = new Set([
-	'/',
-	'/crates',
-	'/enrichment',
-	'/records',
-	'/settings',
-	'/tracks'
-])
+import { getRoutePolicy } from './routePolicy'
 
 /** Keeps Cloud transports out of Demo, public, and future Local entry paths. */
 export function requiresCloudWorkbenchRuntime(path: string): boolean {
-	return CLOUD_WORKBENCH_ROUTES.has(path)
+	return getRoutePolicy(path).cloudWorkbench
 }

--- a/docs/audit-defect-fixes-2026-09-07.md
+++ b/docs/audit-defect-fixes-2026-09-07.md
@@ -1,0 +1,38 @@
+# Audit defect fixes — 7 September 2026
+
+Implementation follow-up to [the codebase audit](./codebase-audit-2026-09-07.md), covering A1–A4. The starting commit is `725357f0929f23358b371221485c0fd6b8ec0719`. These are local changes; no application, Edge Function, or database changes have been deployed to a hosted environment.
+
+## Changes
+
+| Finding                              | Result                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A1: stale manual track edits         | Both editors capture an independent baseline and submit only changed fields. Cloud and browser repositories condition the write on the captured `updated_at` value. A rejected stale edit reloads the latest data and preserves form input. The user can review the saved changes, retain their own edits, and explicitly retry against the newer version. Key/mode and time-signature pairs remain atomic. |
+| A2: abandoned enrichment preparation | Applying becomes busy before asynchronous preparation starts. Preparation checks its original operation, workspace, draft permissions, and page lifetime before dispatch. Reset, lease loss, page departure, or disposal cancels pending preparation; duplicate starts are ignored. Results of already-dispatched writes retain the existing reconciliation and receipt flow.                               |
+| A3: route-policy disagreement        | Authentication, return-path validation, and Cloud runtime loading share one route policy. Static routes accept the router's case-insensitive matching and optional trailing slash, while preserving the original query and hash. Public and Demo routes retain their access classification.                                                                                                                 |
+| A4: queued cleanup shown as failure  | Account deletion returns an explicit cleanup state. The client recognises current and legacy queued responses as successful background cleanup, and reserves cleanup warnings for failed or unconfirmed states. Existing response fields remain available to older clients.                                                                                                                                 |
+
+The timestamp migration advances the version on every track update, including multiple updates within one database transaction and the first edit of a legacy null version. It does not rewrite existing track data. The migration has been applied to the existing local Supabase stack; transactional database fixtures leave application data intact.
+
+## Release dependency
+
+Apply `supabase/migrations/20260907110000_make_track_edit_versions_monotonic.sql` before releasing the track-editor change. Include the updated `delete-account` Edge Function and application in the release. The new client also understands the previous Edge response, and the new Edge response retains its previous fields for older clients.
+
+The migration is compatible with older application code. An application rollback does not require reverting the timestamp trigger. Broader structural cleanup from the audit remains a separate follow-up.
+
+## Validation
+
+Validation used Node 24.18.1 and an exact `npm ci` installation. The lockfile and declared dependency versions are unchanged. Full application verification used `BROWSER_LIBRARY_REQUIRE_FULL_MATRIX=1` and `LOCAL_AUDIO_CACHE_REQUIRE_TIMING_BUDGETS=0`, matching CI. The production build used the CI test-only Supabase configuration.
+
+| Check             | Result                                                                                                                                                                           |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `npm run verify`  | Passed, exit 0; formatting, lint, type checking, conventions, and all included tooling checks passed.                                                                            |
+| Application tests | 158 files; 2,513 tests passed.                                                                                                                                                   |
+| E2E tests         | 8 files; 26 passed, 1 pre-existing conditional test skipped; Chromium, Firefox, and WebKit matrix required.                                                                      |
+| Browser tests     | 10 files; 82 tests passed, including the actual IndexedDB track-edit conflict/retry regression.                                                                                  |
+| Edge Functions    | Type checking and lint passed; 146 tests passed; frozen imports checked.                                                                                                         |
+| Local database    | 14 pgTAP files; 473 assertions passed, including stale updates, null versions, same-transaction version advancement, and ownership. Generated types matched the migrated schema. |
+| Production build  | Passed; generated security headers and client bundle budget passed. Initial JavaScript is 1,106,372 raw / 348,905 gzip bytes.                                                    |
+
+The A1 and A2 regressions were reproduced before their fixes. Added coverage includes both editor surfaces, conflict review/retry, coupled musical values, asynchronous cancellation, duplicate apply starts, cold route variants and subsequent navigation, and compatibility with current and older account-cleanup responses. The final route assertions use the rendered empty-library state of their synthetic fixture.
+
+Local logs: [full verification](/tmp/crate-guide-fixes-complete-verify.log), [focused editor and page checks](/tmp/crate-guide-fixes-final-focused.log), [route checks](/tmp/crate-guide-fixes-final-routing.log), [build](/tmp/crate-guide-fixes-build.log), and [build artifact checks](/tmp/crate-guide-fixes-build-checks.log). This record retains the results after temporary logs expire. Physical-device audio timing and hosted production journeys were not exercised.

--- a/docs/codebase-audit-2026-09-07.md
+++ b/docs/codebase-audit-2026-09-07.md
@@ -1,0 +1,315 @@
+# Crate Guide v2 codebase analysis
+
+Reviewed on 7 September 2026. Source baseline: `725357f0929f23358b371221485c0fd6b8ec0719` on `main`.
+
+This report records the original audit baseline. The subsequent A1–A4 implementation and validation are recorded in [the defect-fix follow-up](./audit-defect-fixes-2026-09-07.md).
+
+## Recommendation
+
+Fund a focused stabilisation and simplification programme. Start with the four concrete defects below, then reduce the responsibilities concentrated in enrichment and separate current device-draft persistence from deferred Local-library functionality. Keep the existing Nuxt, Pinia, repository, and Supabase architecture.
+
+The codebase contains considerable complexity, but much of it protects real production behaviour: account changes during requests, concurrent writes, resumable reviews, uncertain batch outcomes, private cover lifecycle, and historical saved sets. The highest-value cleanup will make those rules easier to understand and apply consistently. Removing them, introducing a new framework, or moving everything into generic CRUD helpers would increase risk.
+
+The main problem is uneven integration between well-developed subsystems. The existing suites pass, yet a form can overwrite newer metadata, an abandoned enrichment preparation can still dispatch a write, route classification can disagree with the router, and the account-deletion client misinterprets its server's normal response. These are better starting points than a repository-wide formatting or renaming exercise.
+
+## Scope and baseline
+
+The review covered application bootstrapping and authentication, domain and repository contracts, Cloud/Demo/browser adapters, Pinia mutation and hydration lifecycles, track and record editing, Discogs transfer, enrichment and Evidence persistence, browser drafts, session playback, Edge Functions, migrations and database tests, build boundaries, CI, and release documentation. Investigation combined source tracing, dependency/caller searches, the existing verification suites, two deliberately failing regression reproductions, a local browser reproduction, and public production response inspection.
+
+No application fixes, dependency changes, commits, or deployments were made. The audit's browser authentication was synthetic and local. Database tests used the existing local Supabase stack and transactional fixtures; production account or library writes were not exercised.
+
+### Source and production are different baselines
+
+- Local and remote `main` both resolved to `725357f0929f23358b371221485c0fd6b8ec0719` during review. Its [GitHub verification run](https://github.com/ryan-voitiskis/crate-guide/actions/runs/34109677973) completed successfully for both application and database jobs.
+- The public response from [crate.guide](https://crate.guide/) at **10:13:06 UTC on 7 September** contained build ID `255966e6-7b29-4198-84b5-dbb7d3b6af67`. This matches the source-controlled [6 September production evidence](/Users/vz/projects/crate-guide/docs/release-evidence/2026-09-06-d8d76df-production.md:1) for `d8d76dfd7950352d3255807bef9229028d69dc2d`. This association comes from the live build ID and recorded release evidence; a fresh Cloudflare deployment API lookup was not performed.
+- The newer source includes the strobe lifecycle fix. The four defect locations below are unchanged between that documented production source and the reviewed head. Their reproductions were local, not observations of affected production users.
+- The working checkout's installed dependencies differed from the lockfile in 28 direct packages, including Nuxt, Pinia, TypeScript, and Playwright. Authoritative application verification therefore used an isolated copy with `npm ci`. The user's existing installation was preserved.
+
+### Where complexity sits
+
+These are physical source-line counts, including comments and blank lines, rather than a complexity score. Tests, generated UI, and generated database types were separated from application source. Test counts include fixtures, tooling tests, and SQL tests; application counts exclude CSS and binary assets.
+
+| Area                                                    | Files |  Lines | Interpretation                                                      |
+| ------------------------------------------------------- | ----: | -----: | ------------------------------------------------------------------- |
+| Application TS/Vue/JS, excluding generated UI and tests |   278 | 62,361 | Substantial for the current product surface                         |
+| Shared source                                           |    10 |  1,276 | Domain and cross-runtime contracts                                  |
+| Edge source                                             |    29 |  2,792 | Relatively bounded server layer                                     |
+| SQL migrations                                          |    33 |  4,788 | Historical schema and integrity contracts                           |
+| Tests and fixtures                                      |   252 | 78,869 | Extensive investment; remaining gaps are about interaction coverage |
+| Generated UI                                            |   150 |  3,164 | A poor primary target for cleanup                                   |
+
+There are 34 application TypeScript/Vue files longer than 500 lines, including six longer than 1,000. The most relevant hotspots are:
+
+| File                                                                                                                         | Lines | Reason to inspect or split                                                       |
+| ---------------------------------------------------------------------------------------------------------------------------- | ----: | -------------------------------------------------------------------------------- |
+| [browserLibraryRepository.ts](/Users/vz/projects/crate-guide/app/repositories/library/browser/browserLibraryRepository.ts:1) | 1,857 | Complete deferred library adapter; separate from the active draft API            |
+| [browserLibraryCodecs.ts](/Users/vz/projects/crate-guide/app/repositories/library/browser/browserLibraryCodecs.ts:1)         | 1,622 | Multiple persisted domains and compatibility rules                               |
+| [useTrackEnrichmentDraftSession.ts](/Users/vz/projects/crate-guide/app/composables/useTrackEnrichmentDraftSession.ts:1)      | 1,620 | Discovery, ownership, renewal, autosave, recovery, and destructive transitions   |
+| [browserWorkspaceCatalog.ts](/Users/vz/projects/crate-guide/app/repositories/library/browser/browserWorkspaceCatalog.ts:1)   | 1,198 | Deferred workspace lifecycle                                                     |
+| [PageTrackEnrichment.vue](/Users/vz/projects/crate-guide/app/components/enrichment/PageTrackEnrichment.vue:1)                | 1,189 | Source selection, review, recovery, and apply UI                                 |
+| [tracksStore.ts](/Users/vz/projects/crate-guide/app/stores/tracksStore.ts:1)                                                 | 1,083 | Hydration, ordinary mutation, optimistic state, and batch outcome reconciliation |
+| [useTrackEnrichmentWorkflow.ts](/Users/vz/projects/crate-guide/app/composables/useTrackEnrichmentWorkflow.ts:1)              |   939 | Parsing, matching, staging, and apply orchestration                              |
+
+The browser repository directory alone contains about **9,300 production source lines**. This is the size of an entangled subsystem, not an estimate of safely deletable code.
+
+## Architecture worth keeping
+
+The shipped application is a Nuxt SPA with Pinia view/cache stores and semantic repository interfaces. Cloud persistence uses Supabase; Demo implements the same read contracts with explicit read-only mutation outcomes. Account identity and Discogs integration have separate ownership from library content. Enrichment additionally persists device-local review state.
+
+| Boundary                      | What is already sound                                                                                                | Cleanup implication                                                                  |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| UI to persistence             | Domain shapes and repository operations keep Supabase query details out of pages and components                      | Improve the existing boundary; avoid introducing a competing data-access layer       |
+| Client to database            | Ownership, relational integrity, privilege, idempotency, and batch/Evidence rules have dedicated database assertions | Preserve enforcement in the database while simplifying callers                       |
+| Account and cover lifecycle   | Recent-authentication checks and durable cleanup intent precede account deletion                                     | Correct the response contract without moving unbounded cleanup back into the request |
+| Long-running client work      | Parsing/audio workers, bounded caches, virtualised surfaces, and stale-work guards already exist                     | Profile and refine ownership instead of removing these protections                   |
+| Verification and dependencies | Locked installs, pinned CI actions, frozen Edge imports, schema parity, and bundle checks are established            | Retain these gates and add the missing integration cases                             |
+
+These boundaries are the foundation for a cleanup. The source does not justify a framework migration, replacement state library, or wholesale server rewrite.
+
+## Four concrete defects to address first
+
+Here, **P1** means prioritise before the next substantial feature tranche because committed data or user intent can be affected. **P2** means a reproducible user-facing defect that should be included in the stabilisation pass. These priorities do not assert a currently observed production incident.
+
+| ID  | Priority | Finding                                                                           | Evidence                                                               |
+| --- | -------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| A1  | P1       | Manual track editing can overwrite newer, untouched metadata                      | Component regression reproduced; unconditional repository write traced |
+| A2  | P1       | Abandoned enrichment preparation can still dispatch a write                       | Deferred-preparation regression reproduced                             |
+| A3  | P2       | Trailing-slash routes disagree with authentication and runtime loading            | Local browser reproduction                                             |
+| A4  | P2       | Successful deferred account cleanup is presented as a warning requiring attention | Server response and client branch traced directly                      |
+
+### A1. Manual edits can silently replace newer metadata
+
+**Trigger:** open a track editor at BPM 128, let another writer change the track to BPM 140, edit only its title, then save. The editor submits BPM 128 alongside the new title.
+
+The form captures its initial values once in [DialogTrackEdit.vue](/Users/vz/projects/crate-guide/app/components/records/DialogTrackEdit.vue:85). Its save handler passes the entire [editor payload](/Users/vz/projects/crate-guide/app/utils/trackEditor.ts:91), including BPM, key, artists, and other fields, to `updateTrack`. [DialogTrackDetails.vue](/Users/vz/projects/crate-guide/app/components/tracks/DialogTrackDetails.vue:95) uses the same pattern. The [Cloud update](/Users/vz/projects/crate-guide/app/repositories/library/cloud/cloudTracksRepository.ts:213) filters by track and owner, with no persisted version precondition.
+
+The focused Nuxt component reproduction produced:
+
+```text
+newerBpm: 140
+submittedBpm: 128
+submittedTitle: 'Retitled Track'
+```
+
+That test inspects the real component's outgoing payload using the existing store fixture. The source trace establishes that an ordinary Cloud update accepts it without a concurrency check. It did not write to production.
+
+Per-entity queues and workspace generations protect other classes of race; they cannot make an old form current or coordinate two clients. Enrichment already has explicit mutation preconditions, which is a useful established pattern.
+
+**Recommended change:** retain an immutable edit baseline, submit only fields the user actually changed, and add an atomic persisted precondition to normal metadata updates. Define conflict behaviour explicitly: preserve the user's input, show the changed current values, and allow a deliberate resolution. A dirty-field patch prevents this particular unrelated-field loss; it does not by itself resolve two writers changing the same field. Audit record and crate metadata editors for the same contract gap after fixing the demonstrated track case.
+
+**Acceptance:** a title-only edit preserves a newer BPM; two edits to the same field produce an explicit conflict; current dialog-generation protections still prevent late completions from closing or changing another dialog. Exercise both track editor surfaces and a real local-database precondition failure.
+
+### A2. Enrichment invalidates an operation after it has already dispatched
+
+In [applyStagedRows](/Users/vz/projects/crate-guide/app/composables/useTrackEnrichmentWorkflow.ts:689), the operation generation is captured before asynchronous preparation. Each `buildTrackEnrichmentUpdate` is awaited, but `isApplying` is set only after preparation, and the first ownership check after preparation occurs **after** `updateTracksBatch` returns.
+
+If the workflow is reset while preparation is awaiting, the old invocation can still set `isApplying`, dispatch the old rows, and then return without clearing the busy state because it no longer owns the operation. Preparation genuinely contains asynchronous work; this is not a purely synchronous theoretical boundary. The read-only draft check also occurs only at entry.
+
+The focused reproduction delayed preparation, called `startAnotherSource()`, then released preparation. It observed:
+
+```text
+busyDuringPreparation: false
+writesAfterReset: 1
+isApplyingAfterReset: true
+```
+
+Existing coverage checks reset after batch dispatch, including suppressing stale progress and results. The missing case is invalidation **before** dispatch.
+
+**Recommended change:** mark the entire prepare/apply operation busy before its first await; capture stable source, workspace, and draft-ownership inputs; check ownership after preparation and immediately before dispatch; prevent duplicate starts; put preparation and completion inside an owned `try/finally`. Lease loss must also prevent a still-undispatched apply.
+
+Keep the existing distinction between cancellation before dispatch and an uncertain outcome after dispatch. Cancelling a UI operation cannot promise that an already-issued database write was rolled back; reconcile those outcomes through the established batch/draft receipt path.
+
+**Acceptance:** reset, route departure, duplicate submission, or lease loss during preparation cannot dispatch a superseded batch. Preparation failures clear the correct busy state. Existing partial-result, stale-workspace, and unknown-outcome tests continue to pass.
+
+### A3. Trailing slashes can break navigation and make public pages require login
+
+[requiresCloudWorkbenchRuntime](/Users/vz/projects/crate-guide/app/utils/workbenchRuntimeAvailability.ts:1) compares exact path strings. [Authentication route classification](/Users/vz/projects/crate-guide/app/utils/authRoutes.ts:15) does the same. The router accepts route variants that those sets reject, while the [workbench plugin](/Users/vz/projects/crate-guide/app/plugins/workbench.client.ts:19) and application bootstrap depend on those classifications.
+
+The local browser reproduced both behaviours:
+
+- Opening `/privacy/` while signed out redirected to login with `/privacy/` as the return target.
+- Opening `/tracks/` and completing the existing synthetic authentication fixture left the page showing “Authentication complete” and “Sign in successful. Redirecting...” at `/tracks/`. The console reported `No workbench runtime is available. The route runtime must load before its stores.`
+
+This is a navigation/bootstrap defect, not an authentication bypass.
+
+**Recommended change:** establish a single route policy based on canonical route identity or resolved metadata, shared by auth and runtime loading. If canonicalising paths, do so before the initial pathname-based bootstrap decision as well as during navigation. Preserve valid query/hash return targets and the existing unsafe-redirect checks.
+
+**Acceptance:** cold entry, login return, and client navigation work for canonical and trailing-slash forms; public legal pages stay public. Add case-variant coverage where the router accepts it. Demo and public entrypoints retain their intended lazy-loading boundaries.
+
+### A4. The account-deletion UI treats the normal cleanup queue state as exceptional
+
+The [delete-account handler](/Users/vz/projects/crate-guide/supabase/functions/delete-account/handler.ts:249) deliberately returns:
+
+```json
+{
+	"success": true,
+	"cover_cleanup_complete": false,
+	"cleanup_queue_complete": false,
+	"cleanup_queued": true
+}
+```
+
+It persists cleanup intent before deleting the auth user; bounded storage traversal belongs to the worker. That is sensible server behaviour.
+
+The [client interpretation](/Users/vz/projects/crate-guide/app/stores/userStore.ts:467) ignores `cleanup_queued`. In the normal current-session success path it displays a 30-second warning that cleanup did not finish and suggests contacting the owner if a cover remains accessible. The state “queued as designed” is therefore indistinguishable from an exceptional incomplete cleanup. This does not mean account deletion itself failed or that the worker is malfunctioning.
+
+**Recommended change:** use an explicit shared cleanup state such as `queued`, `complete`, or `failed`, with a compatible transition for the current response. A successful queued response should give a truthful acknowledgement without implying user intervention is required. Actual worker failures and excessive queue age need an operational signal. Preserve recent-authentication enforcement and enqueue-before-delete ordering.
+
+**Acceptance:** test the actual producer response against the client, rather than a happy-path mock containing only `success: true`. Verify the queued, completed, failed, and local sign-out-failure cases separately.
+
+## Structural cleanup with the best return
+
+### 1. Separate shipped device drafts from deferred Local-library scope
+
+The [plan index](/Users/vz/projects/crate-guide/plans/README.md:35) records **28 completed plans and five deliberately deferred plans**. Portable archives, the signed-out Local product, Local-to-Cloud copying, accountless Discogs, and an offline app shell are not unfinished cleanup obligations. They are product decisions.
+
+Production caller searches found `openBrowserLibraryRepository` and `createBrowserWorkspaceCatalog` only at their declarations; their callers are tests. In contrast, [useTrackEnrichmentDraftSession](/Users/vz/projects/crate-guide/app/composables/useTrackEnrichmentDraftSession.ts:140) actively opens `openBrowserDeviceDraftRepository`.
+
+The complication is that [the active draft repository](/Users/vz/projects/crate-guide/app/repositories/library/browser/browserDeviceDraftRepository.ts:1) imports shared browser schema, types, revisions, broadcasts, and workspace draft operations. Current drafts and future Local work therefore share storage machinery and compatibility history.
+
+First give the active draft subsystem an explicit API and dependency boundary. Then make a product decision about deferred-only adapter and policy code: retain it as a clearly isolated future module with an owner, or remove it from the maintained application after checking dependencies and preserving its history. Keep the deployed IndexedDB schema and upgrade paths required to recover existing drafts. An unused public adapter constructor does not prove that every helper in its directory is unused.
+
+A successful first cleanup PR should make it obvious which code current enrichment needs. File deletion and reduced bundle size are subsequent evidence, not assumptions.
+
+### 2. Extract ownership mechanisms, while retaining domain-specific commands
+
+The application repeatedly coordinates workspace generations, mutation queues, response revisions, optimistic snapshots, and activity counters. Some duplication is an opportunity for small common primitives. Some represents different guarantees and must remain distinct:
+
+| Mechanism                                | What it protects                                             | What it does not establish                        |
+| ---------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------- |
+| Auth/workspace activation generation     | Late work publishing into a replacement account or workspace | Cross-client write conflict detection             |
+| Per-entity queue and optimistic revision | Ordering and rollback within the current client              | Whether an editor's initial data is still current |
+| Persisted precondition or draft lease    | Database/draft conflict and ownership decisions              | Whether the current UI still owns a completion    |
+
+The [repository architecture contract](/Users/vz/projects/crate-guide/docs/library-repository-architecture.md:47) explicitly says an adapter revision is not a cross-client mutation precondition. A1 illustrates why that distinction matters.
+
+Extract a small operation scope, keyed command queue, or owned activity counter only after writing down its guarantees and applying it to one representative store. Keep record/cover changes, crate membership, saved-set history, and enrichment outcomes as semantic operations. Avoid a generic repository wrapper that obscures their different transaction and recovery rules.
+
+### 3. Split enrichment by lifecycle responsibility
+
+The [draft-session state declarations](/Users/vz/projects/crate-guide/app/composables/useTrackEnrichmentDraftSession.ts:157) reveal why changes are difficult: discovery, lease ownership, hydration, autosave, recovery, replacement, deletion, and UI state are coordinated in one closure. The workflow and page add parsing, matching, staging, and persistence concerns around it.
+
+A useful decomposition would give each of these a small, explicit owner:
+
+- Repository connection and draft discovery.
+- Lease acquisition, renewal, takeover, and release.
+- Dirty revisions and serialised autosave.
+- Resume/replacement/deletion commands and their recovery outcomes.
+- Parse/match/review/apply orchestration.
+- View sections consuming a stable, typed view model.
+
+Start with the ownership boundary implicated by A2, then extract one lifecycle at a time with unchanged regression outcomes. Keep codecs and persistence compatibility as pure modules. Where workflow dependencies currently accept an entire Pinia store type, narrow them to the operations actually required. Make critical cross-feature imports explicit so the dependency graph remains understandable despite Nuxt auto-imports.
+
+Splitting a long file into several files that share all the same mutable flags would not solve the problem. The goal is fewer reasons to change each owner, with explicit commands and outcomes between owners.
+
+### 4. Improve tests at integration boundaries
+
+The test investment is valuable and should be preserved. Database suites cover ownership, credentials, function privileges, crate integrity, idempotent imports, cover queues, and Evidence writes. Application and browser suites cover many adverse lifecycle cases. The four findings escaped because the existing suites did not combine the relevant behaviours.
+
+Some application E2E tests use [a synthetic Supabase fixture](/Users/vz/projects/crate-guide/test/e2e/fixtures/authenticatedWorkbench.ts:59), while real SQL verification runs separately. That arrangement is useful for deterministic UI tests but does not validate every client/server response contract.
+
+Add a small number of integrated journeys against an isolated local Supabase environment, using synthetic data:
+
+1. Open editor, perform a competing metadata write, save, and verify persisted values or conflict.
+2. Review enrichment, invalidate during preparation, and verify that no superseded write occurs; separately exercise a dispatched partial/unknown outcome and reload.
+3. Create/update a record with a cover, change crate membership, delete the record, and verify the relevant database and cleanup intent.
+4. Delete a synthetic account and verify the actual response, local transition, and durable cleanup state.
+
+Keep exhaustive permutations in focused tests. Add the route variants to browser coverage and draft takeover cases to the existing multi-browser storage matrix. Require a demonstrated failure-before/fix-after test for each new defect. Avoid coverage-percentage targets or wholesale test rewrites.
+
+### 5. Make the operating documentation current
+
+The [staging runbook](/Users/vz/projects/crate-guide/docs/staging-release-runbook.md:8) still calls July 30 observations “Current evidence,” including pending production migrations and absent browser headers. Later release evidence and the public response contradict that as a present-state description. The repository architecture document also describes browser persistence as unavailable without distinguishing the implemented internal adapter from the deferred product launch.
+
+Keep historical release records intact. Add a short current-state entrypoint that identifies the shipped product scope, current release evidence, production/staging identities, runtime versions, migration compatibility, and applicable rollout procedure. Clearly label the old umbrella-portfolio rehearsal as historical. Archive completed plans out of the active working queue while preserving their links and decisions.
+
+The local dependency drift is a related contributor to confusing verification results. Document and automate a quick version/lockfile preflight; use `npm ci` in isolated verification and release environments. The committed dependency graph passed current audits, so another dependency upgrade campaign is not the immediate cleanup need.
+
+## Operational and performance follow-through
+
+### Finish the browser-policy rollout deliberately
+
+The live response enforced `frame-ancestors 'none'`, `base-uri 'self'`, and `object-src 'none'`. The fuller resource policy, including `script-src` and `connect-src`, remained **Content-Security-Policy-Report-Only**, matching [the source policy](/Users/vz/projects/crate-guide/shared/security/browserHeaders.ts:173). The response had no CSP `report-uri` or `report-to` directive. Cloudflare's separate `cf-nel` reporting configuration reports network errors; it is not a CSP collector.
+
+This is a hardening rollout gap, not a demonstrated injection vulnerability. Collect actionable violation evidence, exercise OAuth, covers, fonts, audio workers/WASM, and supported browsers, then promote the tested resource policy to enforcement. Keep reporting minimal and scrub sensitive URLs and user data.
+
+The application uses local toasts and console errors, and Edge handlers have request-oriented logs. The inspected code did not establish a central browser-error pipeline or alerting for aged/failed cleanup work. Establish a small operational view of failed writes, failed auth completion, queue age/retries, and browser failures. Provider-side monitors might already exist; their current configuration was not verified here.
+
+### Verify recoverability before storage changes
+
+The July production evidence records a manual logical backup and restore rehearsal at that time. It does not prove today's backup schedule or restore point. Confirm current database and cover-storage recovery coverage, retention, restore procedure, and responsible owner before shipping schema or persistence cleanup.
+
+Do not substitute the multi-query observed-library view for a coherent backup. The repository correctly labels that view non-atomic. An internal coherent database snapshot capability also does not, by itself, provide a supported user archive or cover-asset backup.
+
+### Measure the next performance constraint before changing data loading
+
+The audited production build passed its existing bundle boundaries:
+
+| Artifact                                | Raw bytes | Gzip bytes |
+| --------------------------------------- | --------: | ---------: |
+| Initial JavaScript closure              | 1,101,625 |    347,246 |
+| Largest ordinary chunk: enrichment page |   127,783 |     36,978 |
+| Deferred Essentia WASM asset            | 2,505,805 |    780,903 |
+
+The initial limits are 1,130,336 raw / 361,488 gzip, leaving about 2.5% raw headroom. Cloud runtime, the enrichment route, the device draft repository, and the MPEG metadata parser retained their intended lazy boundaries. The WASM figure is not initial JavaScript cost.
+
+[Cloud track hydration](/Users/vz/projects/crate-guide/app/repositories/library/cloud/cloudTracksRepository.ts:158) fetches all owned pages using `select('*')`, including rich metadata. List virtualisation limits rendering work, but it does not limit total fetched or retained data. This is a plausible future scale constraint; the audit did not establish a current production performance incident.
+
+Measure cold mobile startup, library payload size, memory at representative library sizes, route reactivation, and enrichment preparation time. If those measurements justify it, separate lightweight library summaries from detailed Evidence/audio metadata and load detail on demand. Account for matching and session features that require a whole-library view. Keep audio work and parsing in their current bounded workers.
+
+Strict audio timing budgets were disabled for the functional verification run, as in CI. No new physical-device performance benchmark or production percentile measurement was performed.
+
+### Resolve one playback product ambiguity
+
+[Adjusted BPM/key calculation](/Users/vz/projects/crate-guide/app/stores/sessionPlayback.ts:68) applies pitch but does not use the selected deck RPM relative to the track's source RPM. The platter does use deck RPM. Decide whether the speed selector is intended to affect musical playback calculations or only the visual simulation. If it represents playing a 33⅓ RPM recording at 45 RPM, a nominal 120 BPM would become 162 BPM before pitch; the current calculation still returns 120.
+
+This is recorded as a product-semantics decision, not one of the reproduced defects. Preserve the strobe's separate physical and apparent motion, fixed lamp mask, and stop-phase convergence while making any later playback change.
+
+## Recommended delivery sequence
+
+Use a short ordered backlog, with one behaviour or ownership boundary per PR. Reassess after the first structural extraction before committing to a large programme.
+
+| Stage                                       | Work                                                                                                                             | Completion evidence                                                                                                                              |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1. Stabilise                                | A1 and A2 first; A3 and A4 as separate small fixes. Keep any required forward database migration separate from mechanical moves. | Each new regression fails on this baseline and passes with the fix; existing concurrency, database, browser, and batch-outcome suites pass.      |
+| 2. Establish the current operating baseline | Update the current-state documentation; verify backup/restore and cleanup monitoring; finish the CSP rollout with evidence.      | A reader can identify the deployed application and backend state; the operational owner can detect failures and follow a verified recovery path. |
+| 3. Isolate active persistence               | Extract the device-draft API and dependencies; decide whether deferred Local-only code remains maintained.                       | Current drafts resume and upgrade across supported browsers; active product imports have a clear boundary from deferred functionality.           |
+| 4. Reduce lifecycle complexity              | Extract one enrichment lifecycle and one repeated store mechanism as pilots, then expand only where they reduce coupling.        | Fewer independent responsibilities and mutable states per owner, unchanged observable behaviour, preserved stale/conflict semantics.             |
+| 5. Optimise measured bottlenecks            | Gather realistic payload, memory, and timing evidence; make targeted data-loading or rendering changes.                          | Measured improvement on the affected journey, no bundle-boundary regression, and no loss of whole-library functionality.                         |
+
+For each PR, keep refactoring separate from intentional behaviour changes where practical. Run the relevant focused tests during development and the repository's required formatting, conventions, and verification gates before handoff. Before release, verify the exact integrated commit, build artifacts, database compatibility, and staging journeys. Schema changes need forward migrations and compatibility with the application versions that can still be served during rollout.
+
+Retain these production invariants throughout:
+
+- Account and workspace changes invalidate old work; queued commands retain their original owner.
+- RLS, owner checks, private cover access, and server-side mutation preconditions remain authoritative.
+- Record/track/crate relationships and cleanup intent remain transactional where required.
+- Enrichment distinguishes confirmed, conflicted, unattempted, and unknown outcomes; drafts retain recovery information.
+- Existing Evidence and IndexedDB formats remain readable through their supported upgrade paths.
+- Saved-set snapshots preserve history rather than following later library edits.
+- Demo remains isolated and read-only, and public routes do not eagerly acquire Cloud transports.
+
+Success should be measured by eliminated defects, clearer ownership, fewer places to change for a feature, verified recoverability, and maintained performance boundaries. Lines deleted are useful evidence only when those properties improve with them.
+
+## Verification record and limits
+
+The baseline was installed from its lockfile in `/tmp/crate-guide-audit-725357f.ccuS5Q`. Full application verification was rerun with Node 24.18.1, `BROWSER_LIBRARY_REQUIRE_FULL_MATRIX=1`, and `LOCAL_AUDIO_CACHE_REQUIRE_TIMING_BUDGETS=0`.
+
+| Check                    | Result                                                                                                                 |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Full `npm run verify`    | Passed, exit 0, on the final clean Node 24.18.1 run; includes formatting, lint, types, conventions, and tooling checks |
+| Application suites       | 158 files; 2,471 tests passed                                                                                          |
+| E2E suites               | 8 files; 22 passed, 1 skipped; required Chromium/Firefox/WebKit matrix exercised                                       |
+| Browser component suites | 10 files; 81 tests passed                                                                                              |
+| Edge suites              | 146 tests passed; check, lint, and six frozen function imports passed                                                  |
+| Local database           | 13 pgTAP files; 463 assertions passed; generated types matched the migrated schema                                     |
+| Production build         | Passed, including generated security headers and client bundle budget                                                  |
+| Dependency audits        | npm production and full graph: zero reported vulnerabilities; Edge frozen graph: nine packages, no advisories reported |
+| New targeted regressions | Two deliberately failing tests reproduced A1/A2 in the isolated copy; removed before rerunning the unchanged baseline  |
+| Additional browser check | Reproduced A3 using local synthetic authentication                                                                     |
+
+The initial checkout verification was unsuitable as final evidence because its installed graph was stale and the sandbox blocked a local listener. An initial isolated verification later stopped at convention checking because the source archive lacked Git metadata; that audit setup issue was corrected before the final clean rerun. These failures were not classified as application defects. Build and database checks passed separately. After an initial successful build under Node 26.8.1, the build and artifact checks were repeated successfully under Node 24.18.1; the table above uses that final build. Exact-head CI independently passed its Node 24 build.
+
+Useful local investigation artifacts are [the targeted regression patch](/tmp/crate-guide-audit-reproductions.patch), [regression output](/tmp/crate-guide-audit-reproductions.log), [final verification log](/tmp/crate-guide-audit-final-verify.log), [build output](/tmp/crate-guide-audit-node24-build.log), [database output](/tmp/crate-guide-audit-db.log), and [dependency audit output](/tmp/crate-guide-audit-dependencies.log). These temporary files support the investigation; the findings, reproduction triggers, source references, and results are recorded here so the report remains useful after temporary files expire.
+
+Current hosted backup settings, scheduler/alert configuration, remote migration inventory, authenticated production OAuth and write journeys, and production usage/performance telemetry were not revalidated. Those are explicit follow-up checks before the related operational or persistence changes, rather than inferred failures.

--- a/shared/types/accountDeletion.ts
+++ b/shared/types/accountDeletion.ts
@@ -1,0 +1,54 @@
+export type AccountCleanupState = 'queued' | 'complete' | 'failed' | 'unknown'
+
+export type AccountDeletionSuccess = {
+	success: true
+	cleanup_state: AccountCleanupState
+	// Retained while older deployed clients consume these response fields.
+	cover_cleanup_complete: boolean
+	cleanup_queue_complete: boolean
+	cleanup_queued: boolean
+}
+
+export const ACCOUNT_DELETION_QUEUED_RESPONSE: Readonly<AccountDeletionSuccess> =
+	{
+		success: true,
+		cleanup_state: 'queued',
+		cover_cleanup_complete: false,
+		cleanup_queue_complete: false,
+		cleanup_queued: true
+	}
+
+/** Accept the current response and older immediate/queued cleanup responses. */
+export function readAccountCleanupState(
+	response: unknown
+): AccountCleanupState {
+	if (
+		!response ||
+		typeof response !== 'object' ||
+		!('success' in response) ||
+		response.success !== true
+	)
+		return 'unknown'
+	if ('cleanup_state' in response) {
+		const state = response.cleanup_state
+		if (
+			state === 'queued' ||
+			state === 'complete' ||
+			state === 'failed' ||
+			state === 'unknown'
+		)
+			return state
+		return 'unknown'
+	}
+	if ('cleanup_queued' in response && response.cleanup_queued === true)
+		return 'queued'
+	if (
+		('cover_cleanup_complete' in response &&
+			response.cover_cleanup_complete !== true) ||
+		('cleanup_queue_complete' in response &&
+			response.cleanup_queue_complete !== true)
+	)
+		return 'unknown'
+	// The oldest successful response represented synchronous cleanup.
+	return 'complete'
+}

--- a/supabase/functions/delete-account/handler.test.ts
+++ b/supabase/functions/delete-account/handler.test.ts
@@ -428,6 +428,7 @@ Deno.test(
 		assert.equal(didTraverse, false)
 		assert.deepEqual(await response.json(), {
 			success: true,
+			cleanup_state: 'queued',
 			cover_cleanup_complete: false,
 			cleanup_queue_complete: false,
 			cleanup_queued: true

--- a/supabase/functions/delete-account/handler.ts
+++ b/supabase/functions/delete-account/handler.ts
@@ -1,4 +1,5 @@
 import type { User } from '@supabase/supabase-js'
+import { ACCOUNT_DELETION_QUEUED_RESPONSE } from '../../../shared/types/accountDeletion.ts'
 import {
 	type AccountCoverCleanupRepository,
 	createAccountCoverCleanupRepository
@@ -249,15 +250,6 @@ export function createDeleteAccountHandler(
 		// Storage traversal, ordinary queue retirement, and per-user quota cleanup
 		// now belong exclusively to the bounded durable worker. The response never
 		// waits on an account-sized listing after Auth deletion.
-		return jsonResponse(
-			{
-				success: true,
-				cover_cleanup_complete: false,
-				cleanup_queue_complete: false,
-				cleanup_queued: true
-			},
-			headers,
-			200
-		)
+		return jsonResponse(ACCOUNT_DELETION_QUEUED_RESPONSE, headers, 200)
 	}
 }

--- a/supabase/migrations/20260907110000_make_track_edit_versions_monotonic.sql
+++ b/supabase/migrations/20260907110000_make_track_edit_versions_monotonic.sql
@@ -1,0 +1,26 @@
+-- Track editors and enrichment use updated_at as a persisted CAS token.
+-- NOW() is fixed for a transaction, so repeated writes must advance explicitly.
+CREATE FUNCTION public.update_track_updated_at_monotonic()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+	NEW.updated_at := greatest(
+		clock_timestamp(),
+		coalesce(OLD.updated_at, '-infinity'::TIMESTAMPTZ)
+			+ INTERVAL '1 microsecond'
+	);
+	RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_track_updated_at_monotonic()
+FROM PUBLIC, anon, authenticated, service_role;
+
+DROP TRIGGER tracks_update_updated_at_trigger ON public.tracks;
+
+CREATE TRIGGER tracks_update_updated_at_trigger
+BEFORE UPDATE ON public.tracks
+FOR EACH ROW
+EXECUTE FUNCTION public.update_track_updated_at_monotonic();

--- a/supabase/tests/crate_membership.sql
+++ b/supabase/tests/crate_membership.sql
@@ -77,10 +77,6 @@ SELECT is(
 					'records_update_updated_at_trigger'
 				),
 				(
-					'public.tracks'::regclass,
-					'tracks_update_updated_at_trigger'
-				),
-				(
 					'public.sets'::regclass,
 					'sets_update_updated_at_trigger'
 				)
@@ -90,8 +86,8 @@ SELECT is(
 		WHERE trigger.tgfoid = 'public.update_updated_at_column()'::regprocedure
 			AND NOT trigger.tgisinternal
 	),
-	3::BIGINT,
-	'unrelated timestamp triggers still use the shared trigger function'
+	2::BIGINT,
+	'record and saved-set timestamp triggers still use the shared trigger function'
 );
 SELECT is(
 	(

--- a/supabase/tests/track_edit_conflicts.sql
+++ b/supabase/tests/track_edit_conflicts.sql
@@ -1,0 +1,95 @@
+BEGIN;
+
+SELECT plan(10);
+
+INSERT INTO auth.users (id) VALUES
+	('00000000-0907-4000-8000-000000000001'),
+	('00000000-0907-4000-8000-000000000002');
+INSERT INTO public.records (id, user_id, title, artists, labels) VALUES (
+	'10000000-0907-4000-8000-000000000001',
+	'00000000-0907-4000-8000-000000000001',
+	'Edit conflict fixture', '[]'::JSONB, '[]'::JSONB
+);
+INSERT INTO public.tracks (id, record_id, user_id, title, artists, extraartists, genres, bpm, updated_at) VALUES
+	('20000000-0907-4000-8000-000000000001', '10000000-0907-4000-8000-000000000001', '00000000-0907-4000-8000-000000000001', 'Original', '[]'::JSONB, '[]'::JSONB, '[]'::JSONB, 128, '2020-01-01T00:00:00Z'),
+	('20000000-0907-4000-8000-000000000002', '10000000-0907-4000-8000-000000000001', '00000000-0907-4000-8000-000000000001', 'Legacy null version', '[]'::JSONB, '[]'::JSONB, '[]'::JSONB, 128, NULL);
+
+SELECT ok(
+	NOT has_function_privilege('authenticated', 'public.update_track_updated_at_monotonic()', 'EXECUTE')
+	AND NOT has_function_privilege('anon', 'public.update_track_updated_at_monotonic()', 'EXECUTE'),
+	'application roles cannot invoke the version trigger directly'
+);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', '00000000-0907-4000-8000-000000000001', true);
+
+WITH written AS (
+	UPDATE public.tracks SET bpm = 140
+	WHERE id = '20000000-0907-4000-8000-000000000001'
+		AND updated_at = '2020-01-01T00:00:00Z'
+	RETURNING id
+)
+SELECT is(count(*), 1::BIGINT, 'an editor with the current version saves') FROM written;
+
+CREATE TEMP TABLE first_edit_version AS
+SELECT updated_at FROM public.tracks WHERE id = '20000000-0907-4000-8000-000000000001';
+
+UPDATE public.tracks SET title = 'Another editor'
+WHERE id = '20000000-0907-4000-8000-000000000001';
+
+SELECT ok(
+	(SELECT updated_at FROM public.tracks WHERE id = '20000000-0907-4000-8000-000000000001')
+		> (SELECT updated_at FROM first_edit_version),
+	'every write advances the version even in the same transaction'
+);
+
+WITH written AS (
+	UPDATE public.tracks SET title = 'Stale edit'
+	WHERE id = '20000000-0907-4000-8000-000000000001'
+		AND updated_at = (SELECT updated_at FROM first_edit_version)
+	RETURNING id
+)
+SELECT is(count(*), 0::BIGINT, 'a stale editor cannot replace a newer save') FROM written;
+
+SELECT is(
+	(SELECT title FROM public.tracks WHERE id = '20000000-0907-4000-8000-000000000001'),
+	'Another editor', 'a rejected edit preserves the newer title'
+);
+SELECT is(
+	(SELECT bpm::NUMERIC FROM public.tracks WHERE id = '20000000-0907-4000-8000-000000000001'),
+	140::NUMERIC, 'a rejected title edit preserves newer BPM metadata'
+);
+
+WITH written AS (
+	UPDATE public.tracks SET title = 'Reviewed edit'
+	WHERE id = '20000000-0907-4000-8000-000000000001'
+		AND updated_at = (SELECT updated_at FROM public.tracks WHERE id = '20000000-0907-4000-8000-000000000001')
+	RETURNING id
+)
+SELECT is(count(*), 1::BIGINT, 'reviewing the latest version permits a deliberate retry') FROM written;
+
+WITH written AS (
+	UPDATE public.tracks SET title = 'First edit'
+	WHERE id = '20000000-0907-4000-8000-000000000002' AND updated_at IS NULL
+	RETURNING id
+)
+SELECT is(count(*), 1::BIGINT, 'a null legacy version can be edited once') FROM written;
+
+WITH written AS (
+	UPDATE public.tracks SET title = 'Stale null edit'
+	WHERE id = '20000000-0907-4000-8000-000000000002' AND updated_at IS NULL
+	RETURNING id
+)
+SELECT is(count(*), 0::BIGINT, 'a stale null version cannot replace the first edit') FROM written;
+
+SELECT set_config('request.jwt.claim.sub', '00000000-0907-4000-8000-000000000002', true);
+WITH written AS (
+	UPDATE public.tracks SET title = 'Other owner'
+	WHERE id = '20000000-0907-4000-8000-000000000001'
+	RETURNING id
+)
+SELECT is(count(*), 0::BIGINT, 'version support does not bypass track ownership') FROM written;
+
+RESET ROLE;
+SELECT * FROM finish();
+ROLLBACK;

--- a/test/browser/browserLibraryRepository.browser.test.ts
+++ b/test/browser/browserLibraryRepository.browser.test.ts
@@ -800,6 +800,46 @@ describe('browser library repository core contract', () => {
 		})
 	})
 
+	it('rejects a stale track editor without mutating its current metadata', async () => {
+		const { repository, context } =
+			await createRepositoryHarness('track-editor-cas')
+		const dataset = smallDataset()
+		await repository.replaceSnapshot(context, {
+			snapshot: dataset,
+			covers: { 'record-a/cover.webp': smallCover() }
+		})
+		const baseline = dataset.tracks[0]!
+		const first = await repository.tracks.update(context, {
+			id: baseline.id,
+			updates: { bpm: 140 },
+			expectedUpdatedAt: baseline.updated_at
+		})
+		expect(first.status).toBe('success')
+		expect(
+			await repository.tracks.update(context, {
+				id: baseline.id,
+				updates: { title: 'Stale editor' },
+				expectedUpdatedAt: baseline.updated_at
+			})
+		).toMatchObject({ status: 'conflict', reason: 'precondition-failed' })
+		expect(await repository.tracks.list(context)).toMatchObject({
+			status: 'success',
+			value: [expect.objectContaining({ title: baseline.title, bpm: 140 })]
+		})
+		if (first.status !== 'success')
+			throw new Error('Expected the current editor to save')
+		expect(
+			await repository.tracks.update(context, {
+				id: baseline.id,
+				updates: { title: 'Reviewed edit' },
+				expectedUpdatedAt: first.value.updated_at
+			})
+		).toMatchObject({
+			status: 'success',
+			value: { title: 'Reviewed edit', bpm: 140 }
+		})
+	})
+
 	it('does not advance backup revisions or timestamps for semantic resaves', async () => {
 		const { repository, context } =
 			await createRepositoryHarness('semantic-noops')

--- a/test/e2e/auth-navigation.e2e.test.ts
+++ b/test/e2e/auth-navigation.e2e.test.ts
@@ -136,4 +136,48 @@ describe('Authentication navigation', () => {
 			page.getByRole('heading', { name: 'Account', exact: true }).count()
 		).resolves.toBe(0)
 	})
+	it.each(['/tracks/', '/TRACKS/?genre=House#results'])(
+		'loads the workbench after a cold protected route variant %s',
+		async (target) => {
+			const page = await createErrorAwarePage(target)
+			await page.waitForURL(
+				(currentUrl) =>
+					currentUrl.pathname === '/login' &&
+					currentUrl.searchParams.get('redirect') === target
+			)
+			await mockAuthenticatedSupabase(page)
+			await signInViaForm(page, target)
+			await page
+				.getByRole('heading', { name: 'Add records to build your track list' })
+				.waitFor()
+			expect(new URL(page.url()).pathname).toBe(new URL(url(target)).pathname)
+			await page.evaluate(async () => {
+				const app = (
+					window as unknown as {
+						useNuxtApp: () => {
+							$router: { push: (path: string) => Promise<void> }
+						}
+					}
+				).useNuxtApp()
+				await app.$router.push('/Records/')
+			})
+			await page
+				.getByRole('heading', {
+					name: 'Start your record library',
+					exact: true
+				})
+				.waitFor()
+		}
+	)
+
+	it.each(['/privacy/', '/PRIVACY/'])(
+		'keeps the legal route variant %s public on cold entry',
+		async (target) => {
+			const page = await createErrorAwarePage(target)
+			await page
+				.getByRole('heading', { name: 'Privacy Notice', exact: true })
+				.waitFor()
+			expect(new URL(page.url()).pathname).toBe(target)
+		}
+	)
 })

--- a/test/nuxt/enrichment-page.nuxt.test.ts
+++ b/test/nuxt/enrichment-page.nuxt.test.ts
@@ -307,6 +307,7 @@ function createWorkflow(): WorkflowHarness {
 		clearStagedRows: vi.fn(),
 		openApplyReview: vi.fn(),
 		applyStagedRows: vi.fn().mockResolvedValue(undefined),
+		cancelPendingApply: vi.fn(),
 		returnToReview: vi.fn()
 	} as unknown as WorkflowHarness
 }
@@ -433,6 +434,16 @@ describe('enrichment page wiring', () => {
 		workflowFactory.mockReset()
 		draftSessionFactory.mockReset()
 		document.body.innerHTML = ''
+	})
+
+	it('cancels pending preparation when the enrichment page unmounts', async () => {
+		const { workflow, wrapper } = await mountPage([true, true])
+		vi.mocked(workflow.cancelParsing).mockClear()
+		vi.mocked(workflow.cancelPendingApply).mockClear()
+		wrapper.unmount()
+		wrappers.delete(wrapper)
+		expect(workflow.cancelParsing).toHaveBeenCalledOnce()
+		expect(workflow.cancelPendingApply).toHaveBeenCalledOnce()
 	})
 
 	it('adapts source, file, review, dialog, and summary UI events to the workflow contract', async () => {

--- a/test/nuxt/track-editors.nuxt.test.ts
+++ b/test/nuxt/track-editors.nuxt.test.ts
@@ -273,24 +273,9 @@ describe('track editor dialogs', () => {
 		expect(editPayload).toEqual(detailsPayload)
 		expect(editPayload).toEqual({
 			title: 'Normalized Track',
-			artists: [
-				{ discogs_id: 1, name: 'Test Artist', role: null },
-				{ discogs_id: 2, name: 'Second Artist', role: 'Remix' }
-			],
-			extraartists: [
-				{ name: 'Guest Artist', role: 'Vocals' },
-				{ name: 'Engineer', role: 'Mastered By' }
-			],
 			position: 'B2',
 			duration: 225000,
-			bpm: 128.5,
-			rpm: 33,
-			key: 0,
-			mode: 0,
-			genres: ['House'],
-			time_signature_upper: 4,
-			time_signature_lower: 4,
-			playable: true
+			bpm: 128.5
 		})
 	})
 
@@ -508,6 +493,91 @@ describe('track editor dialogs', () => {
 
 			secondUpdate.resolve(null)
 			await settleDialog()
+		}
+	)
+	it.each(['edit', 'details'] as const)(
+		'saves only changed fields from the immutable %s editor baseline',
+		async (surface) => {
+			const editor =
+				surface === 'edit'
+					? await mountAddOrEditDialog('edit')
+					: await mountDetailsDialog()
+			if (surface === 'details') await enterDetailsEditMode()
+			const baselineUpdatedAt = editor.track.updated_at
+			editor.track.bpm = 140
+			editor.track.updated_at = '2026-09-07T12:00:00.000001Z'
+			vi.mocked(editor.tracks.updateTrack).mockResolvedValue(editor.track)
+			await getBody().get('input[name="title"]').setValue('Retitled Track')
+			await getButton(
+				surface === 'edit' ? 'Update Track' : 'Save Changes'
+			).trigger('click')
+			await vi.waitFor(() =>
+				expect(editor.tracks.updateTrack).toHaveBeenCalledOnce()
+			)
+			const [, patch, options] = vi.mocked(editor.tracks.updateTrack).mock
+				.calls[0]!
+			expect(patch).toEqual({ title: 'Retitled Track' })
+			expect(options).toMatchObject({ expectedUpdatedAt: baselineUpdatedAt })
+		}
+	)
+	it.each(['edit', 'details'] as const)(
+		'keeps the %s editor input through a conflict and explicitly reviews a new baseline',
+		async (surface) => {
+			const editor =
+				surface === 'edit'
+					? await mountAddOrEditDialog('edit')
+					: await mountDetailsDialog()
+			if (surface === 'details') await enterDetailsEditMode()
+			const saveLabel = surface === 'edit' ? 'Update Track' : 'Save Changes'
+			const latest = createMockTrack({
+				...editor.track,
+				title: 'Title from another editor',
+				bpm: 140,
+				updated_at: '2026-09-07T12:00:00.000001Z'
+			})
+			vi.mocked(editor.tracks.updateTrack).mockImplementationOnce(
+				async (_id, _patch, options) => {
+					options?.onConflict?.(latest)
+					return null
+				}
+			)
+			await getBody().get('input[name="title"]').setValue('My title')
+			await getButton(saveLabel).trigger('click')
+			await vi.waitFor(() =>
+				expect(getBody().text()).toContain(
+					'This track changed while you were editing.'
+				)
+			)
+			expect(getBody().text()).toContain('Title from another editor')
+			expect(getBody().text()).toContain('140')
+			expect(getBody().get('input[name="title"]').element).toHaveProperty(
+				'value',
+				'My title'
+			)
+			expect(getButton(saveLabel).attributes('disabled')).toBeDefined()
+			await getButton('Keep my edits and review').trigger('click')
+			await settleDialog()
+			expect(getBody().get('input[name="title"]').element).toHaveProperty(
+				'value',
+				'My title'
+			)
+			expect(getBody().get('input[name="bpm"]').element).toHaveProperty(
+				'value',
+				'140'
+			)
+			vi.mocked(editor.tracks.updateTrack).mockResolvedValueOnce({
+				...latest,
+				title: 'My title'
+			})
+			await getButton(saveLabel).trigger('click')
+			await vi.waitFor(() =>
+				expect(editor.tracks.updateTrack).toHaveBeenCalledTimes(2)
+			)
+			expect(vi.mocked(editor.tracks.updateTrack).mock.calls[1]).toEqual([
+				editor.track.id,
+				{ title: 'My title' },
+				expect.objectContaining({ expectedUpdatedAt: latest.updated_at })
+			])
 		}
 	)
 })


### PR DESCRIPTION
Fix four reproduced production defects: manual track edits now reject stale saves and retain user input for review; abandoned enrichment preparation cannot dispatch writes; authentication and Cloud runtime loading share route matching; and queued account cleanup is presented as successful background work.

The forward timestamp migration must be applied before the new track editor is released. The delete-account response remains compatible with older clients, and the new client accepts the existing queued response. No dependency versions change.

Validation: full local verification passed (2,513 application, 26 E2E, 82 browser, and 146 Edge tests); 473 local database assertions and generated schema parity passed; the production build, security headers, and bundle budget passed. One existing headed-WebKit test remains conditionally skipped. Exact-commit CI and hosted release checks will be recorded before production completion.
