### PR TITLE
fix(tracks): preserve duration through conflict review

### DIFF
--- a/app/utils/trackEditor.test.ts
+++ b/app/utils/trackEditor.test.ts
@@ -138,6 +138,22 @@ describe('buildTrackEditorPayload', () => {
 })
 
 describe('track editor patches', () => {
+	it.each([null, 0, 180, 1000, 180999])(
+		'preserves an untouched duration of %s milliseconds after conflict review',
+		(duration) => {
+			const baseline = createTrackEditorBaseline(createTrack({ duration }))
+			const reviewed = { ...baseline.payload, title: 'Reviewed title' }
+			const payload = buildTrackEditorPayload(
+				trackToEditorValues(reviewed),
+				reviewed.artists,
+				reviewed.extraartists
+			)
+			expect(buildTrackEditorPatch(baseline.payload, payload)).toEqual({
+				title: 'Reviewed title'
+			})
+		}
+	)
+
 	it('does not mutate its baseline when the source artist metadata changes', () => {
 		const track = createTrack()
 		const baseline = createTrackEditorBaseline(track)

--- a/app/utils/trackEditor.ts
+++ b/app/utils/trackEditor.ts
@@ -68,7 +68,8 @@ export function trackToEditorValues(
 	return {
 		title: track.title || '',
 		position: track.position || '',
-		duration: msToMMSS(track.duration),
+		// A normalized conflict baseline can contain a meaningful zero duration.
+		duration: track.duration === 0 ? '0:00' : msToMMSS(track.duration),
 		bpm: track.bpm?.toString() || '',
 		keyComposite: createKeyComposite(track.key, track.mode),
 		genres: [...(track.genres || [])],

--- a/test/nuxt/track-editors.nuxt.test.ts
+++ b/test/nuxt/track-editors.nuxt.test.ts
@@ -520,9 +520,13 @@ describe('track editor dialogs', () => {
 			expect(options).toMatchObject({ expectedUpdatedAt: baselineUpdatedAt })
 		}
 	)
-	it.each(['edit', 'details'] as const)(
-		'keeps the %s editor input through a conflict and explicitly reviews a new baseline',
-		async (surface) => {
+	it.each(
+		(['edit', 'details'] as const).flatMap((surface) =>
+			[null, 0, 180, 180999].map((duration) => ({ surface, duration }))
+		)
+	)(
+		'keeps the $surface editor input and the latest $duration millisecond duration through conflict review',
+		async ({ surface, duration }) => {
 			const editor =
 				surface === 'edit'
 					? await mountAddOrEditDialog('edit')
@@ -532,6 +536,7 @@ describe('track editor dialogs', () => {
 			const latest = createMockTrack({
 				...editor.track,
 				title: 'Title from another editor',
+				duration,
 				bpm: 140,
 				updated_at: '2026-09-07T12:00:00.000001Z'
 			})


### PR DESCRIPTION
An explicit conflict-review retry could clear an untouched sub-second track duration because the normalized zero duration rendered as an empty field. Keep zero represented as `0:00`, so retrying a title edit preserves the latest stored duration and other concurrent metadata.

Regression tests cover null, zero, sub-second, and fractional-second durations in the shared patch builder and both track editors. The 180 ms case reproduced the defect in all three tests before the fix. `npm run format` and the complete `npm run verify` passed: 2,524 application tests, 26 E2E passes with one existing conditional skip, 82 browser tests, 146 Edge tests, and convention/type/lint checks.
