### PR TITLE
refactor(drafts): extract lease ownership lifecycle

### DIFF
--- a/app/composables/useTrackEnrichmentDraftSession.ts
+++ b/app/composables/useTrackEnrichmentDraftSession.ts
@@ -12,19 +12,18 @@ import type {
 	TrackEnrichmentApplyAttempt,
 	TrackEnrichmentWorkflow
 } from '~/composables/useTrackEnrichmentWorkflow'
-import {
-	BROWSER_DRAFT_LEASE_RENEW_INTERVAL_MS,
-	type BrowserClaimedDraft,
-	type BrowserDeviceDraftRepository,
-	type BrowserDraftLease,
-	type BrowserLibraryDependencies,
-	type BrowserWorkflowDraft,
-	type BrowserWorkflowDraftEntry,
-	type BrowserWorkspaceIdentity
+import type {
+	BrowserClaimedDraft,
+	BrowserDeviceDraftRepository,
+	BrowserLibraryDependencies,
+	BrowserWorkflowDraft,
+	BrowserWorkflowDraftEntry,
+	BrowserWorkspaceIdentity
 } from '~/repositories/deviceDrafts/contracts'
 import type { TrackEnrichmentDraftPartialOutcome } from '~/types/trackEnrichmentDraft'
 import { hydrateTrackEnrichmentDraft } from '~/utils/trackEnrichmentDraftHydration'
 import { mapTrackEnrichmentDraftBatchOutcome } from '~/utils/trackEnrichmentDraftOutcome'
+import { createTrackEnrichmentDraftOwnership } from '~/utils/trackEnrichmentDraftOwnership'
 import { projectTrackEnrichmentDraft } from '~/utils/trackEnrichmentDraftProjection'
 import { createTrackEnrichmentDraftWorkspaceIdentity } from '~/utils/trackEnrichmentDraftWorkspaceIdentity'
 import type { WorkbenchRuntime } from '~/utils/workbenchPinia'
@@ -33,7 +32,6 @@ import type { LibraryRecord, LibraryTrack } from '~~/shared/types/library'
 const TRACK_ENRICHMENT_DRAFT_AUTOSAVE_DELAY_MS = 500
 
 type DraftSessionTimer = ReturnType<typeof globalThis.setTimeout>
-type DraftSessionInterval = ReturnType<typeof globalThis.setInterval>
 type DraftMutationQueue = { tail: Promise<void> }
 
 export type TrackEnrichmentDraftSaveState =
@@ -146,12 +144,8 @@ export function useTrackEnrichmentDraftSession(
 		dependencies.randomUUID ?? (() => globalThis.crypto.randomUUID())
 	const scheduleTimeout = dependencies.setTimeout ?? globalThis.setTimeout
 	const cancelTimeout = dependencies.clearTimeout ?? globalThis.clearTimeout
-	const scheduleInterval = dependencies.setInterval ?? globalThis.setInterval
-	const cancelInterval = dependencies.clearInterval ?? globalThis.clearInterval
 	const autosaveDelayMs =
 		dependencies.autosaveDelayMs ?? TRACK_ENRICHMENT_DRAFT_AUTOSAVE_DELAY_MS
-	const leaseRenewIntervalMs =
-		dependencies.leaseRenewIntervalMs ?? BROWSER_DRAFT_LEASE_RENEW_INTERVAL_MS
 	const hydrateDraft = dependencies.hydrateDraft ?? hydrateTrackEnrichmentDraft
 
 	const discoveryState = ref<TrackEnrichmentDraftDiscoveryState>('idle')
@@ -171,8 +165,6 @@ export function useTrackEnrichmentDraftSession(
 	let repository: BrowserDeviceDraftRepository | null = null
 	let unsubscribe: (() => void) | null = null
 	let deviceRevision = 0
-	let ownedLease: BrowserDraftLease | null = null
-	let ownedDraftId: string | null = null
 	let persistedDraft: BrowserWorkflowDraft | null = null
 	let partialOutcomes: TrackEnrichmentDraftPartialOutcome[] = []
 	let replacementTarget: ReplacementTarget | null = null
@@ -184,7 +176,6 @@ export function useTrackEnrichmentDraftSession(
 	let lifecycleGeneration = 0
 	let suppressAutosave = false
 	let saveTimer: DraftSessionTimer | null = null
-	let renewTimer: DraftSessionInterval | null = null
 	let savePromise: Promise<void> | null = null
 	let refreshPromise: Promise<void> | null = null
 	let repositoryRuntimeIdentity: BrowserWorkspaceIdentity | null = null
@@ -194,14 +185,46 @@ export function useTrackEnrichmentDraftSession(
 	let locallyDeletingDraftId: string | null = null
 	let mutationQueue: DraftMutationQueue = { tail: Promise.resolve() }
 	const reviewedAtByRowId = new Map<string, string>()
+	const ownership = createTrackEnrichmentDraftOwnership({
+		ownerToken,
+		getRepository: () => repository,
+		getDeviceRevision: () => deviceRevision,
+		setDeviceRevision: (revision) => {
+			deviceRevision = revision
+		},
+		captureLifecycleGuard,
+		runSerializedMutation,
+		onChange: () => {
+			sessionRevision.value += 1
+		},
+		onRenewed: (currentDraftId, lease) => {
+			if (activeEntry.value?.draft.metadata.id === currentDraftId) {
+				activeEntry.value = {
+					...activeEntry.value,
+					lease: { status: 'live', lease }
+				}
+			}
+		},
+		onRenewalFailed: (error) => {
+			const hadUnsavedWork =
+				hasUnsavedChanges.value || saveState.value === 'saving'
+			resetOwnership()
+			if (hadUnsavedWork) saveState.value = 'failed'
+			saveErrorCode.value = errorCode(error)
+			void refreshDiscovery()
+		},
+		leaseRenewIntervalMs: dependencies.leaseRenewIntervalMs,
+		setInterval: dependencies.setInterval,
+		clearInterval: dependencies.clearInterval
+	})
 
 	const hasDraft = computed(() => activeEntry.value !== null)
 	const isOwned = computed(() => {
 		void sessionRevision.value
 		return (
-			ownedLease !== null &&
-			ownedDraftId !== null &&
-			activeEntry.value?.draft.metadata.id === ownedDraftId
+			ownership.lease !== null &&
+			ownership.draftId !== null &&
+			activeEntry.value?.draft.metadata.id === ownership.draftId
 		)
 	})
 	const isReadOnly = computed(
@@ -341,7 +364,7 @@ export function useTrackEnrichmentDraftSession(
 				isTransitioning.value = false
 				if (workflow.rows.value.length > 0) {
 					workflow.setReviewReadOnly(
-						isDraftMissingConflict.value || !ownedLease
+						isDraftMissingConflict.value || !ownership.lease
 					)
 				}
 			}
@@ -354,24 +377,13 @@ export function useTrackEnrichmentDraftSession(
 		saveTimer = null
 	}
 
-	function clearRenewTimer() {
-		if (renewTimer === null) return
-		cancelInterval(renewTimer)
-		renewTimer = null
-	}
-
 	function resetOwnership() {
-		clearRenewTimer()
-		ownedLease = null
-		ownedDraftId = null
-		sessionRevision.value += 1
+		ownership.reset()
 		workflow.setReviewReadOnly(workflow.rows.value.length > 0)
 	}
 
 	function setClaimed(claimed: BrowserClaimedDraft) {
-		ownedDraftId = claimed.draft.id
-		ownedLease = claimed.lease
-		sessionRevision.value += 1
+		ownership.accept(claimed.draft.id, claimed.lease)
 		persistedDraft = claimed.draft
 		observeTimestamp(claimed.draft.updatedAt)
 		draftId = claimed.draft.id
@@ -380,7 +392,7 @@ export function useTrackEnrichmentDraftSession(
 			structuredClone(outcome)
 		)
 		workflow.setReviewReadOnly(false)
-		startRenewingLease()
+		ownership.startRenewing()
 	}
 
 	function setActiveEntry(entry: BrowserWorkflowDraftEntry | null) {
@@ -477,12 +489,12 @@ export function useTrackEnrichmentDraftSession(
 					workflow.setReviewReadOnly(workflow.rows.value.length > 0)
 					return
 				}
-				const currentOwnedRevision = ownedLease?.leaseRevision ?? null
+				const currentOwnedRevision = ownership.lease?.leaseRevision ?? null
 				const observedRevision = observedLeaseRevision(entry)
 				if (
-					ownedDraftId &&
+					ownership.draftId &&
 					(!entry ||
-						entry.draft.metadata.id !== ownedDraftId ||
+						entry.draft.metadata.id !== ownership.draftId ||
 						currentOwnedRevision !== observedRevision)
 				) {
 					resetOwnership()
@@ -491,9 +503,9 @@ export function useTrackEnrichmentDraftSession(
 					hasUnsavedChanges.value &&
 					entry?.draft.status === 'ready' &&
 					persistedDraft &&
-					ownedDraftId === entry.draft.metadata.id &&
-					ownedLease &&
-					observedRevision === ownedLease.leaseRevision &&
+					ownership.draftId === entry.draft.metadata.id &&
+					ownership.lease &&
+					observedRevision === ownership.lease.leaseRevision &&
 					persistedDraft.id === entry.draft.metadata.id &&
 					persistedDraft.draftRevision === entry.draft.metadata.draftRevision
 				)
@@ -506,7 +518,7 @@ export function useTrackEnrichmentDraftSession(
 					setActiveEntry(entry)
 				}
 				if (workflow.rows.value.length > 0) {
-					workflow.setReviewReadOnly(!ownedLease)
+					workflow.setReviewReadOnly(!ownership.lease)
 				}
 			} catch (error) {
 				if (
@@ -533,76 +545,6 @@ export function useTrackEnrichmentDraftSession(
 		await created
 	}
 
-	function startRenewingLease() {
-		clearRenewTimer()
-		if (!ownedLease || !ownedDraftId) return
-		renewTimer = scheduleInterval(() => {
-			void renewLease()
-		}, leaseRenewIntervalMs)
-	}
-
-	async function renewLease() {
-		const isCurrentLifecycle = captureLifecycleGuard()
-		const generation = lifecycleGeneration
-		await runSerializedMutation(async () => {
-			const currentRepository = repository
-			const lease = ownedLease
-			const currentDraftId = ownedDraftId
-			if (
-				!currentRepository ||
-				!lease ||
-				!currentDraftId ||
-				!isCurrentLifecycle()
-			) {
-				return
-			}
-			try {
-				const result = await currentRepository.renewDraftLease(
-					currentDraftId,
-					ownerToken,
-					{
-						deviceRevision,
-						leaseRevision: lease.leaseRevision
-					}
-				)
-				if (
-					generation !== lifecycleGeneration ||
-					currentRepository !== repository ||
-					!isCurrentLifecycle()
-				) {
-					return
-				}
-				deviceRevision = result.deviceRevision
-				ownedLease = result.value
-				if (
-					activeEntry.value &&
-					activeEntry.value.draft.metadata.id === currentDraftId
-				) {
-					activeEntry.value = {
-						...activeEntry.value,
-						lease: { status: 'live', lease: result.value }
-					}
-				}
-				sessionRevision.value += 1
-				startRenewingLease()
-			} catch (error) {
-				if (
-					generation !== lifecycleGeneration ||
-					currentRepository !== repository ||
-					!isCurrentLifecycle()
-				) {
-					return
-				}
-				const hadUnsavedWork =
-					hasUnsavedChanges.value || saveState.value === 'saving'
-				resetOwnership()
-				if (hadUnsavedWork) saveState.value = 'failed'
-				saveErrorCode.value = errorCode(error)
-				void refreshDiscovery(generation)
-			}
-		})
-	}
-
 	async function releaseAndCloseRepository(
 		outgoingQueue: DraftMutationQueue = mutationQueue,
 		outgoingSave: Promise<void> | null = savePromise
@@ -610,47 +552,27 @@ export function useTrackEnrichmentDraftSession(
 		const currentRepository = repository
 		if (!currentRepository) return
 		clearSaveTimer()
-		clearRenewTimer()
+		ownership.stopRenewing()
 		unsubscribe?.()
 		unsubscribe = null
 		const preDrainDraftId =
-			ownedDraftId ?? draftId ?? persistedDraft?.id ?? null
-		ownedLease = null
-		ownedDraftId = null
-		sessionRevision.value += 1
+			ownership.draftId ?? draftId ?? persistedDraft?.id ?? null
+		ownership.reset()
 		try {
 			await outgoingSave
 			await drainMutationQueue(outgoingQueue)
 			const currentDraftId =
-				ownedDraftId ?? draftId ?? persistedDraft?.id ?? preDrainDraftId
-			clearRenewTimer()
-			if (ownedLease || ownedDraftId) {
-				ownedLease = null
-				ownedDraftId = null
-				sessionRevision.value += 1
-			}
+				ownership.draftId ?? draftId ?? persistedDraft?.id ?? preDrainDraftId
+			ownership.stopRenewing()
+			if (ownership.lease || ownership.draftId) ownership.reset()
 			if (currentDraftId) {
-				const fresh = await currentRepository.readDraft(currentDraftId)
-				if (fresh.value?.lease.status === 'live') {
-					await currentRepository.releaseDraftLease(
-						currentDraftId,
-						ownerToken,
-						{
-							deviceRevision: fresh.deviceRevision,
-							leaseRevision: fresh.value.lease.lease.leaseRevision
-						}
-					)
-				}
+				await ownership.releaseObserved(currentRepository, currentDraftId)
 			}
 		} catch {
 			// A takeover or workspace replacement can legitimately fence this tab.
 		} finally {
-			clearRenewTimer()
-			if (ownedLease || ownedDraftId) {
-				ownedLease = null
-				ownedDraftId = null
-				sessionRevision.value += 1
-			}
+			ownership.stopRenewing()
+			if (ownership.lease || ownership.draftId) ownership.reset()
 			currentRepository.close()
 			if (repository === currentRepository) {
 				repository = null
@@ -837,7 +759,7 @@ export function useTrackEnrichmentDraftSession(
 			repositoryRuntimeIdentity?.workspaceId === captured.context.workspaceId &&
 			repositoryRuntimeIdentity.repositoryId === captured.context.repositoryId
 		if (!isCurrentOperation()) return
-		if (activeEntry.value && !ownedLease && !replacementTarget) {
+		if (activeEntry.value && !ownership.lease && !replacementTarget) {
 			workflow.setReviewReadOnly(true)
 			return
 		}
@@ -900,15 +822,15 @@ export function useTrackEnrichmentDraftSession(
 				deviceRevision = result.deviceRevision
 				claimed = result.value
 			} else {
-				if (!ownedLease) throw new Error('Draft lease is not owned.')
+				if (!ownership.lease) throw new Error('Draft lease is not owned.')
 				const result = await currentRepository.writeDraft(draft, ownerToken, {
 					deviceRevision,
 					draftRevision: persistedDraft.draftRevision,
-					leaseRevision: ownedLease.leaseRevision
+					leaseRevision: ownership.lease.leaseRevision
 				})
 				if (!isCurrentOperation()) return
 				deviceRevision = result.deviceRevision
-				claimed = { draft: result.value, lease: ownedLease }
+				claimed = { draft: result.value, lease: ownership.lease }
 			}
 			if (!isCurrentOperation()) return
 			setClaimed(claimed)
@@ -978,7 +900,7 @@ export function useTrackEnrichmentDraftSession(
 			suppressAutosave ||
 			isDraftMissingConflict.value ||
 			workflow.rows.value.length === 0 ||
-			(activeEntry.value && !ownedLease && !replacementTarget)
+			(activeEntry.value && !ownership.lease && !replacementTarget)
 		) {
 			return
 		}
@@ -1042,10 +964,11 @@ export function useTrackEnrichmentDraftSession(
 		}
 		suppressAutosave = false
 		const ownsCurrentLease =
-			ownedDraftId === expectedDraftId &&
-			ownedLease !== null &&
+			ownership.draftId === expectedDraftId &&
+			ownership.lease !== null &&
 			activeEntry.value?.lease.status === 'live' &&
-			activeEntry.value.lease.lease.leaseRevision === ownedLease.leaseRevision
+			activeEntry.value.lease.lease.leaseRevision ===
+				ownership.lease.leaseRevision
 		workflow.setReviewReadOnly(!ownsCurrentLease)
 		replacementTarget = null
 		sessionRevision.value += 1
@@ -1090,7 +1013,6 @@ export function useTrackEnrichmentDraftSession(
 		isHydrating.value = true
 		workflow.setReviewReadOnly(true)
 		recoveryMessage.value = null
-		let entry = initialEntry
 		try {
 			const read = await currentRepository.readDraft(
 				initialEntry.draft.metadata.id
@@ -1104,31 +1026,21 @@ export function useTrackEnrichmentDraftSession(
 				return false
 			}
 			deviceRevision = read.deviceRevision
-			entry = read.value
+			let entry = read.value
 			setActiveEntry(entry)
 			if (entry.lease.status !== 'live') {
 				try {
-					const result = await runSerializedMutation(async () => {
-						if (!isCurrentOperation()) return null
-						return await currentRepository.claimDraft(
-							entry.draft.metadata.id,
-							ownerToken,
-							deviceRevision
-						)
-					})
-					if (!result || !isCurrentOperation()) {
-						return false
-					}
-					deviceRevision = result.deviceRevision
-					ownedLease = result.value.lease
-					ownedDraftId = entry.draft.metadata.id
-					sessionRevision.value += 1
+					const claimed = await ownership.claim(
+						entry.draft.metadata.id,
+						isCurrentOperation
+					)
+					if (!claimed || !isCurrentOperation()) return false
 					entry = {
-						draft: result.value.draft,
-						lease: { status: 'live', lease: result.value.lease }
+						draft: claimed.draft,
+						lease: { status: 'live', lease: claimed.lease }
 					}
 					if (entry.draft.status !== 'ready') return false
-					startRenewingLease()
+					ownership.startRenewing()
 				} catch (error) {
 					if (!isCurrentOperation()) return false
 					if (!isConflict(error)) throw error
@@ -1165,28 +1077,21 @@ export function useTrackEnrichmentDraftSession(
 		isTakingOver.value = true
 		workflow.setReviewReadOnly(true)
 		try {
-			const result = await runSerializedMutation(async () => {
-				if (!isCurrentOperation()) return null
-				return await currentRepository.takeOverDraft(
-					entry.draft.metadata.id,
-					ownerToken,
-					{ deviceRevision, leaseRevision }
-				)
-			})
-			if (!result || !isCurrentOperation()) return false
-			deviceRevision = result.deviceRevision
-			ownedDraftId = entry.draft.metadata.id
-			ownedLease = result.value.lease
-			sessionRevision.value += 1
-			if (result.value.draft.status === 'ready') {
-				persistedDraft = result.value.draft.draft
+			const claimed = await ownership.takeOver(
+				entry.draft.metadata.id,
+				leaseRevision,
+				isCurrentOperation
+			)
+			if (!claimed || !isCurrentOperation()) return false
+			if (claimed.draft.status === 'ready') {
+				persistedDraft = claimed.draft.draft
 			}
 			const claimedEntry: BrowserWorkflowDraftEntry = {
-				draft: result.value.draft,
-				lease: { status: 'live', lease: result.value.lease }
+				draft: claimed.draft,
+				lease: { status: 'live', lease: claimed.lease }
 			}
 			setActiveEntry(claimedEntry)
-			startRenewingLease()
+			ownership.startRenewing()
 			const hydrated = await hydrateReadyDraftEntry(
 				claimedEntry,
 				isCurrentOperation
@@ -1206,29 +1111,13 @@ export function useTrackEnrichmentDraftSession(
 		isCurrentOperation: () => boolean
 	) {
 		try {
-			return await runSerializedMutation(async () => {
-				const entry = activeEntry.value
-				const currentRepository = repository
-				if (!entry || !currentRepository || !isCurrentOperation()) return false
-				if (ownedLease && ownedDraftId === entry.draft.metadata.id) return true
-				if (entry.lease.status === 'live') return false
-				const result = await currentRepository.claimDraft(
-					entry.draft.metadata.id,
-					ownerToken,
-					deviceRevision
-				)
-				if (!isCurrentOperation()) return false
-				deviceRevision = result.deviceRevision
-				ownedDraftId = entry.draft.metadata.id
-				ownedLease = result.value.lease
-				activeEntry.value = {
-					draft: result.value.draft,
-					lease: { status: 'live', lease: result.value.lease }
+			return await ownership.ensureOwned(
+				() => activeEntry.value,
+				isCurrentOperation,
+				(entry) => {
+					activeEntry.value = entry
 				}
-				sessionRevision.value += 1
-				startRenewingLease()
-				return true
-			})
+			)
 		} catch {
 			if (!isCurrentOperation()) return false
 			await refreshDiscovery()
@@ -1255,7 +1144,7 @@ export function useTrackEnrichmentDraftSession(
 			const result = await runSerializedMutation(async () => {
 				const currentRepository = repository
 				const entry = activeEntry.value
-				const lease = ownedLease
+				const lease = ownership.lease
 				if (
 					!currentRepository ||
 					!entry ||
@@ -1371,7 +1260,7 @@ export function useTrackEnrichmentDraftSession(
 				draftId: currentEntry.draft.metadata.id,
 				draftRevision: currentEntry.draft.metadata.draftRevision,
 				observedLeaseRevision:
-					ownedLease?.leaseRevision ?? observedLeaseRevision(currentEntry)
+					ownership.lease?.leaseRevision ?? observedLeaseRevision(currentEntry)
 			}
 			sessionRevision.value += 1
 			persistedDraft = null
@@ -1410,36 +1299,12 @@ export function useTrackEnrichmentDraftSession(
 			) {
 				return false
 			}
-			if (repository && ownedLease && ownedDraftId) {
-				try {
-					const result = await runSerializedMutation(async () => {
-						const currentRepository = repository
-						const lease = ownedLease
-						const currentDraftId = ownedDraftId
-						if (
-							!currentRepository ||
-							!lease ||
-							!currentDraftId ||
-							!isCurrentOperation()
-						) {
-							return null
-						}
-						return await currentRepository.releaseDraftLease(
-							currentDraftId,
-							ownerToken,
-							{
-								deviceRevision,
-								leaseRevision: lease.leaseRevision
-							}
-						)
-					})
-					if (!result || !isCurrentOperation()) return false
-					deviceRevision = result.deviceRevision
-				} catch {
-					if (!isCurrentOperation()) return false
-					return false
-				}
+			try {
+				if (!(await ownership.release(isCurrentOperation))) return false
+			} catch {
+				return false
 			}
+			if (!isCurrentOperation()) return false
 			resetOwnership()
 			suppressAutosave = true
 			workflow.startAnotherSource()
@@ -1578,7 +1443,7 @@ export function useTrackEnrichmentDraftSession(
 
 	onScopeDispose(() => {
 		clearSaveTimer()
-		clearRenewTimer()
+		ownership.stopRenewing()
 		void flushSave().finally(() => {
 			lifecycleGeneration += 1
 			return releaseAndCloseRepository()

--- a/app/utils/trackEnrichmentDraftOwnership.test.ts
+++ b/app/utils/trackEnrichmentDraftOwnership.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+	BrowserDraftLease,
+	BrowserWorkflowDraftEntry
+} from '~/repositories/deviceDrafts/contracts'
+import {
+	type TrackEnrichmentDraftOwnershipDependencies,
+	createTrackEnrichmentDraftOwnership
+} from '~/utils/trackEnrichmentDraftOwnership'
+
+const NOW = '2026-09-08T00:00:00.000Z'
+const draft: BrowserWorkflowDraftEntry['draft'] = {
+	status: 'invalid',
+	metadata: {
+		id: 'draft-a',
+		kind: 'track-enrichment',
+		draftRevision: 3,
+		updatedAt: NOW
+	}
+}
+
+function lease(revision: number): BrowserDraftLease {
+	return {
+		leaseRevision: revision,
+		acquiredAt: NOW,
+		renewedAt: NOW,
+		expiresAt: '2026-09-08T00:01:00.000Z'
+	}
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void
+	let reject!: (error: unknown) => void
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res
+		reject = rej
+	})
+	return { promise, resolve, reject }
+}
+
+function harness() {
+	type Repository = NonNullable<
+		ReturnType<TrackEnrichmentDraftOwnershipDependencies['getRepository']>
+	>
+	const repository = {
+		claimDraft: vi.fn<Repository['claimDraft']>(),
+		takeOverDraft: vi.fn<Repository['takeOverDraft']>(),
+		renewDraftLease: vi.fn<Repository['renewDraftLease']>(),
+		releaseDraftLease: vi.fn<Repository['releaseDraftLease']>(),
+		readDraft: vi.fn<Repository['readDraft']>()
+	}
+	let generation = 0
+	let deviceRevision = 1
+	let tail: Promise<unknown> = Promise.resolve()
+	function runSerializedMutation<T>(operation: () => Promise<T>) {
+		const result = tail.then(operation)
+		tail = result.catch(() => undefined)
+		return result
+	}
+	function captureLifecycleGuard() {
+		const captured = generation
+		return () => generation === captured
+	}
+	const onChange = vi.fn()
+	const onRenewed = vi.fn()
+	const onRenewalFailed = vi.fn(() => ownership.reset())
+	const ownership = createTrackEnrichmentDraftOwnership({
+		ownerToken: 'owner-a',
+		getRepository: () => repository,
+		getDeviceRevision: () => deviceRevision,
+		setDeviceRevision: (value) => {
+			deviceRevision = value
+		},
+		captureLifecycleGuard,
+		runSerializedMutation,
+		onChange,
+		onRenewed,
+		onRenewalFailed,
+		leaseRenewIntervalMs: 1000
+	})
+	return {
+		ownership,
+		repository,
+		onChange,
+		onRenewed,
+		onRenewalFailed,
+		captureLifecycleGuard,
+		runSerializedMutation,
+		get deviceRevision() {
+			return deviceRevision
+		},
+		set deviceRevision(value: number) {
+			deviceRevision = value
+		},
+		invalidate() {
+			generation += 1
+			ownership.reset()
+		}
+	}
+}
+
+beforeEach(() => {
+	vi.useFakeTimers()
+})
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+describe('draft ownership', () => {
+	it.each(['claim', 'takeOver'] as const)(
+		'%s waits for autosave and uses its committed device revision',
+		async (operation) => {
+			const h = harness()
+			const save = deferred<undefined>()
+			void h.runSerializedMutation(async () => {
+				await save.promise
+				h.deviceRevision = 8
+			})
+			const result = { value: { draft, lease: lease(5) }, deviceRevision: 9 }
+			h.repository.claimDraft.mockResolvedValue(result)
+			h.repository.takeOverDraft.mockResolvedValue(result)
+			const guard = h.captureLifecycleGuard()
+			const pending =
+				operation === 'claim'
+					? h.ownership.claim('draft-a', guard)
+					: h.ownership.takeOver('draft-a', 4, guard)
+			await Promise.resolve()
+			expect(h.repository.claimDraft).not.toHaveBeenCalled()
+			expect(h.repository.takeOverDraft).not.toHaveBeenCalled()
+			save.resolve(undefined)
+			expect(await pending).toEqual(result.value)
+			if (operation === 'claim') {
+				expect(h.repository.claimDraft).toHaveBeenCalledWith(
+					'draft-a',
+					'owner-a',
+					8
+				)
+			} else {
+				expect(h.repository.takeOverDraft).toHaveBeenCalledWith(
+					'draft-a',
+					'owner-a',
+					{ deviceRevision: 8, leaseRevision: 4 }
+				)
+			}
+			expect(h.deviceRevision).toBe(9)
+			expect(h.ownership.lease).toEqual(lease(5))
+		}
+	)
+
+	it('serializes overlapping renewals and release using each preceding result', async () => {
+		const h = harness()
+		h.ownership.accept('draft-a', lease(4))
+		const first = deferred<{
+			value: BrowserDraftLease
+			deviceRevision: number
+		}>()
+		h.repository.renewDraftLease
+			.mockReturnValueOnce(first.promise)
+			.mockResolvedValueOnce({ value: lease(6), deviceRevision: 3 })
+		h.repository.releaseDraftLease.mockResolvedValue({
+			value: undefined,
+			deviceRevision: 4
+		})
+		const pending = [h.ownership.renew(), h.ownership.renew()]
+		const released = h.ownership.release(h.captureLifecycleGuard())
+		await Promise.resolve()
+		expect(h.repository.renewDraftLease).toHaveBeenCalledTimes(1)
+		expect(h.repository.releaseDraftLease).not.toHaveBeenCalled()
+		first.resolve({ value: lease(5), deviceRevision: 2 })
+		await Promise.all(pending)
+		expect(await released).toBe(true)
+		expect(h.repository.renewDraftLease).toHaveBeenNthCalledWith(
+			2,
+			'draft-a',
+			'owner-a',
+			{ deviceRevision: 2, leaseRevision: 5 }
+		)
+		expect(h.repository.releaseDraftLease).toHaveBeenCalledWith(
+			'draft-a',
+			'owner-a',
+			{ deviceRevision: 3, leaseRevision: 6 }
+		)
+		expect(h.deviceRevision).toBe(4)
+	})
+
+	it('ignores a claim that completes after its workspace is replaced', async () => {
+		const h = harness()
+		const claimed = deferred<{
+			value: { draft: typeof draft; lease: BrowserDraftLease }
+			deviceRevision: number
+		}>()
+		h.repository.claimDraft.mockReturnValue(claimed.promise)
+		const pending = h.ownership.claim('draft-a', h.captureLifecycleGuard())
+		await Promise.resolve()
+		expect(h.repository.claimDraft).toHaveBeenCalledOnce()
+		h.invalidate()
+		claimed.resolve({ value: { draft, lease: lease(5) }, deviceRevision: 2 })
+		expect(await pending).toBeNull()
+		expect(h.ownership.draftId).toBeNull()
+		expect(h.deviceRevision).toBe(1)
+		expect(vi.getTimerCount()).toBe(0)
+	})
+
+	it.each(['resolve', 'reject'] as const)(
+		'discards a pending renewal that will %s after a workspace switch',
+		async (outcome) => {
+			const h = harness()
+			h.ownership.accept('draft-a', lease(4))
+			const renewed = deferred<{
+				value: BrowserDraftLease
+				deviceRevision: number
+			}>()
+			h.repository.renewDraftLease.mockReturnValue(renewed.promise)
+			const pending = h.ownership.renew()
+			await Promise.resolve()
+			h.invalidate()
+			if (outcome === 'resolve')
+				renewed.resolve({ value: lease(5), deviceRevision: 2 })
+			else renewed.reject(new Error('Superseded lease'))
+			await pending
+			expect(h.onRenewed).not.toHaveBeenCalled()
+			expect(h.onRenewalFailed).not.toHaveBeenCalled()
+			expect(h.deviceRevision).toBe(1)
+			expect(vi.getTimerCount()).toBe(0)
+		}
+	)
+
+	it('stops automatic renewal when ownership is lost', async () => {
+		const h = harness()
+		const error = new Error('Lease taken over')
+		h.repository.renewDraftLease.mockRejectedValue(error)
+		h.ownership.accept('draft-a', lease(4))
+		h.ownership.startRenewing()
+		await vi.advanceTimersByTimeAsync(1000)
+		expect(h.onRenewalFailed).toHaveBeenCalledWith(error)
+		expect(h.ownership.lease).toBeNull()
+		expect(vi.getTimerCount()).toBe(0)
+		await vi.advanceTimersByTimeAsync(5000)
+		expect(h.repository.renewDraftLease).toHaveBeenCalledOnce()
+	})
+
+	it('requires ownership before deleting an invalid draft and refuses another live lease', async () => {
+		const h = harness()
+		let entry: BrowserWorkflowDraftEntry = {
+			draft,
+			lease: { status: 'live', lease: lease(4) }
+		}
+		const onClaimed = vi.fn((claimed: BrowserWorkflowDraftEntry) => {
+			entry = claimed
+		})
+		const ensure = () =>
+			h.ownership.ensureOwned(() => entry, h.captureLifecycleGuard(), onClaimed)
+		expect(await ensure()).toBe(false)
+		expect(h.repository.claimDraft).not.toHaveBeenCalled()
+		entry = { ...entry, lease: { status: 'expired', lease: lease(4) } }
+		h.repository.claimDraft.mockResolvedValue({
+			value: { draft, lease: lease(5) },
+			deviceRevision: 2
+		})
+		expect(await ensure()).toBe(true)
+		expect(entry.lease).toEqual({ status: 'live', lease: lease(5) })
+		expect(h.ownership.lease).toEqual(lease(5))
+		expect(h.deviceRevision).toBe(2)
+		expect(await ensure()).toBe(true)
+		expect(h.repository.claimDraft).toHaveBeenCalledOnce()
+	})
+
+	it('releases the lease observed after a drained first save despite reset local ownership', async () => {
+		const h = harness()
+		h.ownership.reset()
+		h.repository.readDraft.mockResolvedValue({
+			value: { draft, lease: { status: 'live', lease: lease(7) } },
+			deviceRevision: 12
+		})
+		h.repository.releaseDraftLease.mockResolvedValue({
+			value: undefined,
+			deviceRevision: 13
+		})
+		await h.ownership.releaseObserved(h.repository, 'draft-a')
+		expect(h.repository.releaseDraftLease).toHaveBeenCalledWith(
+			'draft-a',
+			'owner-a',
+			{ deviceRevision: 12, leaseRevision: 7 }
+		)
+		expect(h.deviceRevision).toBe(1)
+	})
+})

--- a/app/utils/trackEnrichmentDraftOwnership.ts
+++ b/app/utils/trackEnrichmentDraftOwnership.ts
@@ -1,0 +1,230 @@
+import {
+	BROWSER_DRAFT_LEASE_RENEW_INTERVAL_MS,
+	type BrowserClaimedDraftState,
+	type BrowserDeviceDraftReadResult,
+	type BrowserDeviceDraftRepository,
+	type BrowserDraftLease,
+	type BrowserWorkflowDraftEntry
+} from '~/repositories/deviceDrafts/contracts'
+
+type OwnershipRepository = Pick<
+	BrowserDeviceDraftRepository,
+	| 'claimDraft'
+	| 'takeOverDraft'
+	| 'renewDraftLease'
+	| 'releaseDraftLease'
+	| 'readDraft'
+>
+
+export type TrackEnrichmentDraftOwnershipDependencies = {
+	ownerToken: string
+	getRepository: () => OwnershipRepository | null
+	getDeviceRevision: () => number
+	setDeviceRevision: (revision: number) => void
+	captureLifecycleGuard: () => () => boolean
+	runSerializedMutation: <T>(operation: () => Promise<T>) => Promise<T>
+	onChange: () => void
+	onRenewed: (draftId: string, lease: BrowserDraftLease) => void
+	onRenewalFailed: (error: unknown) => void
+	leaseRenewIntervalMs?: number
+	setInterval?: typeof globalThis.setInterval
+	clearInterval?: typeof globalThis.clearInterval
+}
+
+// Ownership uses the session's mutation queue and device revision. Giving lease
+// operations a separate queue would race autosave's compare-and-swap writes.
+export function createTrackEnrichmentDraftOwnership(
+	dependencies: TrackEnrichmentDraftOwnershipDependencies
+) {
+	const {
+		ownerToken,
+		getRepository,
+		getDeviceRevision,
+		setDeviceRevision,
+		captureLifecycleGuard,
+		runSerializedMutation,
+		onChange,
+		onRenewed,
+		onRenewalFailed
+	} = dependencies
+	const scheduleInterval = dependencies.setInterval ?? globalThis.setInterval
+	const cancelInterval = dependencies.clearInterval ?? globalThis.clearInterval
+	const intervalMs =
+		dependencies.leaseRenewIntervalMs ?? BROWSER_DRAFT_LEASE_RENEW_INTERVAL_MS
+	let ownedDraftId: string | null = null
+	let ownedLease: BrowserDraftLease | null = null
+	let timer: ReturnType<typeof globalThis.setInterval> | null = null
+
+	function stopRenewing() {
+		if (timer === null) return
+		cancelInterval(timer)
+		timer = null
+	}
+
+	function reset() {
+		stopRenewing()
+		ownedDraftId = null
+		ownedLease = null
+		onChange()
+	}
+
+	function accept(draftId: string, lease: BrowserDraftLease) {
+		ownedDraftId = draftId
+		ownedLease = lease
+		onChange()
+	}
+
+	function startRenewing() {
+		stopRenewing()
+		if (!ownedDraftId || !ownedLease) return
+		timer = scheduleInterval(() => {
+			void renew()
+		}, intervalMs)
+	}
+
+	async function renew() {
+		const isCurrentLifecycle = captureLifecycleGuard()
+		await runSerializedMutation(async () => {
+			const repository = getRepository()
+			const lease = ownedLease
+			const draftId = ownedDraftId
+			if (!repository || !lease || !draftId || !isCurrentLifecycle()) return
+			try {
+				const result = await repository.renewDraftLease(draftId, ownerToken, {
+					deviceRevision: getDeviceRevision(),
+					leaseRevision: lease.leaseRevision
+				})
+				if (repository !== getRepository() || !isCurrentLifecycle()) return
+				setDeviceRevision(result.deviceRevision)
+				ownedLease = result.value
+				onRenewed(draftId, result.value)
+				onChange()
+				startRenewing()
+			} catch (error) {
+				if (repository !== getRepository() || !isCurrentLifecycle()) return
+				// The session coordinates lost ownership with its unsaved-work state.
+				onRenewalFailed(error)
+			}
+		})
+	}
+
+	async function acquire(
+		draftId: string,
+		isCurrentOperation: () => boolean,
+		operation: (
+			repository: OwnershipRepository,
+			deviceRevision: number
+		) => Promise<BrowserDeviceDraftReadResult<BrowserClaimedDraftState>>
+	) {
+		const repository = getRepository()
+		if (!repository) return null
+		const result = await runSerializedMutation(async () => {
+			if (!isCurrentOperation()) return null
+			return await operation(repository, getDeviceRevision())
+		})
+		if (!result || !isCurrentOperation()) return null
+		setDeviceRevision(result.deviceRevision)
+		accept(draftId, result.value.lease)
+		return result.value
+	}
+
+	function claim(draftId: string, isCurrentOperation: () => boolean) {
+		return acquire(draftId, isCurrentOperation, (repository, revision) =>
+			repository.claimDraft(draftId, ownerToken, revision)
+		)
+	}
+
+	function takeOver(
+		draftId: string,
+		leaseRevision: number,
+		isCurrentOperation: () => boolean
+	) {
+		return acquire(draftId, isCurrentOperation, (repository, revision) =>
+			repository.takeOverDraft(draftId, ownerToken, {
+				deviceRevision: revision,
+				leaseRevision
+			})
+		)
+	}
+
+	async function ensureOwned(
+		getEntry: () => BrowserWorkflowDraftEntry | null,
+		isCurrentOperation: () => boolean,
+		onClaimed: (entry: BrowserWorkflowDraftEntry) => void
+	) {
+		return await runSerializedMutation(async () => {
+			const entry = getEntry()
+			const repository = getRepository()
+			if (!entry || !repository || !isCurrentOperation()) return false
+			if (ownedLease && ownedDraftId === entry.draft.metadata.id) return true
+			if (entry.lease.status === 'live') return false
+			const result = await repository.claimDraft(
+				entry.draft.metadata.id,
+				ownerToken,
+				getDeviceRevision()
+			)
+			if (!isCurrentOperation()) return false
+			setDeviceRevision(result.deviceRevision)
+			ownedDraftId = entry.draft.metadata.id
+			ownedLease = result.value.lease
+			onClaimed({
+				draft: result.value.draft,
+				lease: { status: 'live', lease: result.value.lease }
+			})
+			onChange()
+			startRenewing()
+			return true
+		})
+	}
+
+	async function release(isCurrentOperation: () => boolean) {
+		if (!getRepository() || !ownedLease || !ownedDraftId) return true
+		const result = await runSerializedMutation(async () => {
+			const repository = getRepository()
+			const lease = ownedLease
+			const draftId = ownedDraftId
+			if (!repository || !lease || !draftId || !isCurrentOperation())
+				return null
+			return await repository.releaseDraftLease(draftId, ownerToken, {
+				deviceRevision: getDeviceRevision(),
+				leaseRevision: lease.leaseRevision
+			})
+		})
+		if (!result || !isCurrentOperation()) return false
+		setDeviceRevision(result.deviceRevision)
+		return true
+	}
+
+	// Teardown calls this only after draining pending saves and their shared queue.
+	// A first save can have acquired a lease after teardown cleared local ownership.
+	async function releaseObserved(
+		repository: OwnershipRepository,
+		draftId: string
+	) {
+		const fresh = await repository.readDraft(draftId)
+		if (fresh.value?.lease.status !== 'live') return
+		await repository.releaseDraftLease(draftId, ownerToken, {
+			deviceRevision: fresh.deviceRevision,
+			leaseRevision: fresh.value.lease.lease.leaseRevision
+		})
+	}
+
+	return {
+		get draftId() {
+			return ownedDraftId
+		},
+		get lease() {
+			return ownedLease
+		},
+		accept,
+		reset,
+		claim,
+		takeOver,
+		ensureOwned,
+		renew,
+		startRenewing,
+		stopRenewing,
+		release,
+		releaseObserved
+	}
+}

--- a/docs/metadata-concurrency.md
+++ b/docs/metadata-concurrency.md
@@ -1,0 +1,39 @@
+# Record and crate editor concurrency
+
+Confirmed on 8 September 2026 against the migrated local Supabase stack, using two independently authenticated clients for one disposable account. Source baseline: `845bcb3308a35b4dfe8d4a24a9b10d8de4529b39` (PR #17). The ownership extraction does not change these paths.
+
+## Observed behavior
+
+Both editors can silently overwrite a newer edit from another session. This is a persisted lost update, not merely an optimistic display problem.
+
+| Entity | Session A opens                              | Session B saves                                                                  | Session A then saves                                       | Persisted result                                                               |
+| ------ | -------------------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Record | Original title, no year, original artist     | Year `2024`, artist `Concurrent artist`                                          | A new title with the original form's year and artist       | New title, year reset to `null`, original artist restored                      |
+| Crate  | Original name, description, colour `#112233` | A new description and colour `#445566`; adds a record through the membership RPC | A new name with the original form's description and colour | New name, original description and colour restored; record membership survives |
+
+Every save above succeeded through real Auth, PostgREST, row-level policies, and database triggers. The probe used the exact editor metadata fields and repository owner/id filters, rather than mocked repository outcomes. It did not automate the editor UI; the connection to each editor is established by the source paths below. No production data was changed.
+
+The temporary probe asserted both lost updates, advancing record timestamps, preserved crate membership, and cleanup. It passed in the local integration project. Its disposable Auth user, library rows, crate, cover objects, quota state, and cleanup jobs were verified absent afterward. A permanent test should assert conflict protection when the fix is implemented, rather than preserve today's faulty behavior as a passing contract.
+
+## Cause
+
+- [DialogRecordDetails](../app/components/records/DialogRecordDetails.vue) always submits title, year, and artists from the open form. [cloudRecordsRepository](../app/repositories/library/cloud/cloudRecordsRepository.ts) updates by record ID and owner, without checking the version the editor opened.
+- [DialogCrateDetails](../app/components/crates/DialogCrateDetails.vue) always submits name, description, and colour. [cloudCratesRepository](../app/repositories/library/cloud/cloudCratesRepository.ts) likewise updates metadata without an expected row version. Its failure handler currently reinitializes the form, which would discard input if a conflict were surfaced without changing the UI handling.
+- Per-record queues and optimistic ownership tokens protect mutations within one running store. They cannot prevent another tab or device from saving an older form.
+- Crate membership already uses atomic add/remove RPCs; the editor does not submit the membership array. Preserve that separation.
+
+To repeat the experiment, create a fixture through `createLocalFixture` in `test/integration/fixtures/localSupabase.ts`; sign a second client into that exact fixture account using the guarded local URL; select an initial row with client A; update the other fields with client B; then submit the metadata fields shown above with client A. Assert persisted values, dispose the fixture in `finally`, and additionally verify no `public.crates` rows remain for the exact fixture user. Do not run this against a hosted project or retain a test asserting lost updates as correct behavior.
+
+## Recommended next implementation
+
+Extend the existing track-editor conflict contract in a separate correctness PR:
+
+1. Capture the record/crate version when the form is initialized. Carry it through the store and repository mutation as `expectedUpdatedAt`; keep the full timestamp string, including database precision. Apply it in the same database statement as the update. A zero-row version match is a conflict, not a successful save or a generic transport error.
+2. Preserve the user's fields on conflict, fetch the current server row, show what changed, and require explicit review before retry. Reuse the track editor's established behavior. Sending only dirty fields reduces incidental overwrites but does not protect against two people changing the same field.
+3. Make record `updated_at` strictly monotonic before relying on it for compare-and-swap. The initial record trigger uses transaction-time `NOW()`. Crates already have the monotonic trigger introduced by `20260719121000_add_atomic_crate_membership.sql`; tracks received the equivalent guarantee in the audit release.
+4. Carry the precondition through the record cover coordinator. A rejected save must not remove the current cover or leave the newly uploaded candidate behind. Preserve reconciliation of uncertain responses and account/workspace switching.
+5. Implement equivalent outcomes in the Demo adapter and update store consumers deliberately. Preserve atomic crate membership, per-entity ordering, existing optimistic rollback ownership, and stale-workspace guards.
+
+Acceptance requires two-session browser/integration tests for both editors, same-field and different-field conflicts, input preservation and reviewed retry, the record cover path, deletion/workspace switches during save, and simultaneous crate membership changes. Add a database regression for monotonically advancing record versions within one transaction. Run the existing full verification and scoped cleanup checks before release.
+
+This investigation changes no persistence contracts or production behavior. The confirmed defects should be addressed before the next broad store or autosave extraction.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -49,9 +49,13 @@ The browser uses the real Supabase client. Edge requests execute the production 
 
 ## Recovery activation
 
-Recovery is still an open operational requirement. The dashboard at the last release showed no automatic backups. The July manual database restore rehearsal is historical evidence; it is not a current recovery point.
+Recovery is still an open operational requirement. A fresh production dashboard check on 8 September 2026 still showed **Last backup: No backups**. The July manual database restore rehearsal is historical evidence; it is not a current recovery point.
+
+The same check confirmed that Chrome can access both Crate Guide projects, while the default Supabase CLI identity cannot list either. CLI sign-in to the owning account is required. The installed CLI's named-profile attempt failed with `LegacyProfileLoadError`; no token was created or credentials replaced. Cloudflare's scoped R2 bucket-list call reported that R2 must be enabled on the account hosting Crate Guide. Ryan has been asked to enable it or identify an existing private bucket. No storage, billing, scheduler, or production data was changed.
 
 The proposed baseline is a daily encrypted backup to independent private storage, with 30 daily copies and a monthly isolated restore rehearsal. Before activation, confirm the destination, retention, encryption-key ownership, and access for an unattended operator. Do not upload production data to a guessed destination or use CI logs/artifacts as an implicit backup store.
+
+After access is unblocked, verify visibility of the exact production project above; establish scoped object-storage access and an encryption key whose recovery owner can recover it independently of the application; then capture and restore one complete set before scheduling daily runs. Do not reset the production database password to satisfy a CLI example. Supabase's [backup and restore guide](https://supabase.com/docs/guides/platform/migrating-within-supabase/backup-restore) is the starting point for database connection/export compatibility, and its [backup documentation](https://supabase.com/docs/guides/platform/backups) explains why Storage bytes need their own capture. If R2 is selected, follow Cloudflare's [private bucket setup](https://developers.cloudflare.com/r2/buckets/create-buckets/); keep public access disabled.
 
 A complete backup set must contain:
 

--- a/plans/078-recovery-and-draft-ownership.md
+++ b/plans/078-recovery-and-draft-ownership.md
@@ -1,0 +1,30 @@
+# Recovery and draft ownership
+
+Status: ownership extraction verified; metadata investigation complete; recovery awaiting access and storage. Approved by Ryan on 8 September 2026 after PR #17 merged.
+
+## Scope
+
+1. Verify current Supabase access, prepare independent database and cover recovery, and prove an isolated restore before activating backups. Production data must have an explicit private destination and an encryption/recovery owner.
+2. Extract draft claim, renewal, takeover, and release into one ownership controller. Preserve IndexedDB data, lease semantics, public session behavior, and the shared mutation queue used by autosave.
+3. Reproduce record/crate metadata concurrency behavior with disposable local fixtures. Record confirmed defects and the smallest appropriate remediation before changing persistence contracts.
+
+## Working baseline
+
+- Main source: `845bcb3308a35b4dfe8d4a24a9b10d8de4529b39`; merged-source CI passed.
+- The default CLI currently authenticates but does not list either Crate Guide project. The existing legacy profile is unusable, and an attempted separate profile fails with `LegacyProfileLoadError`. No credentials were replaced.
+- Chrome still sees production and staging in organization `grxffkeajwssrcfwtxny`. CLI sign-in has been requested while local work proceeds.
+- Independent backup storage and recovery-key ownership remain to be established. Backup capability is not activated.
+
+## Implementation and investigation
+
+- `createTrackEnrichmentDraftOwnership` now owns local lease state, claim/takeover, renewal timers, and release. It receives the session's existing mutation queue, device revision, and lifecycle guard so autosave and ownership still serialize against the same revision. The session retains hydration, recovery messages, unsaved-work handling, and public UI behavior. There is no IndexedDB schema or persistence-contract change.
+- Calls back into the session recheck operation validity after the new asynchronous boundary. Teardown still drains the pending save and original queue, rereads the resulting persisted lease, and releases with that observed revision.
+- Nine focused controller tests pass, including fresh compare-and-swap revisions after queued writes, overlapping renewal/release, superseded responses, expired/foreign ownership, and release after the first save. The existing 37 draft-session tests also pass after extraction.
+- [Record/crate concurrency investigation](../docs/metadata-concurrency.md) confirms both persisted overwrite defects using two real local sessions. All synthetic data was removed and verified. The proposed next correctness PR adds version preconditions and input-preserving conflict review; it keeps crate membership atomic and handles cover cleanup explicitly.
+- The production dashboard still reports no backups. R2 is not enabled on the intended Cloudflare account. CLI sign-in and the storage choice have been requested; [current operations](../docs/operations.md#recovery-activation) records the exact activation sequence. No production backup, restore, or schedule has been claimed complete.
+
+## Verification
+
+`npm run format`, `npm run check:conventions`, and `npm run verify:full` passed locally on 8 September 2026. This includes 2,535 application tests, 26 end-to-end tests (one existing skip), 82 browser tests, 146 Edge tests, 473 database assertions, and five real local Supabase integration tests, plus type checking, build, security headers, schema parity, and bundle budgets. Existing browser tests cover reopening a persisted review and cross-session takeover/deletion without resurrecting dirty work.
+
+The local stack was neither reset nor stopped. Each integration fixture's teardown verified its own rows, objects, Auth user, and cleanup state; a final read-only query confirmed zero disposable integration Auth fixtures. Recovery remains unverified until a complete production backup set has been restored in isolation. No new production release was made.


### PR DESCRIPTION
Draft ownership was interleaved with autosave, hydration, and recovery inside the enrichment session. Extract claim, takeover, renewal timers, and lease release into a dedicated controller while retaining the same shared mutation queue and device revision. The session rechecks operation validity when control returns across the new async boundary; teardown still drains pending saves before rereading and releasing the persisted lease. No IndexedDB schema or public session behavior changes.

Add nine focused ownership tests alongside the existing 37 session tests. Also record a real local two-session reproduction of record/crate metadata overwrites and the proposed version-precondition fix. Recovery documentation now reflects current access blockers: Chrome can see the projects, the CLI cannot, and private backup storage remains to be provisioned. Backups are not activated by this PR.

Validation: `npm run format`, `npm run check:conventions`, and `npm run verify:full` passed locally: 2,535 application tests, 26 end-to-end tests (one existing skip), 82 browser tests, 146 Edge tests, 473 database assertions, and five real Supabase integration tests, plus build/schema/header/bundle checks. All disposable integration fixtures were removed and checked; the developer stack was never reset or stopped. No production deployment was performed.
